### PR TITLE
all: location overriding method At()

### DIFF
--- a/analyzer/testdata/src/gocritic/f1.go
+++ b/analyzer/testdata/src/gocritic/f1.go
@@ -78,9 +78,9 @@ func mapKey(x, y int) {
 	_ = map[int]int{}
 	_ = map[int]int{x + 1: 1, x + 2: 2}
 	_ = map[int]int{x: 1, x: 2} // want `suspicious duplicate key x`
-	_ = map[int]int{            // want `suspicious duplicate key x`
+	_ = map[int]int{
 		10: 1,
-		x:  2,
+		x:  2, // want `suspicious duplicate key x`
 		30: 3,
 		x:  4,
 		50: 5,

--- a/analyzer/testdata/src/gocritic/gocritic.rules.go
+++ b/analyzer/testdata/src/gocritic/gocritic.rules.go
@@ -46,7 +46,8 @@ func _(m fluent.Matcher) {
 
 	m.Match(`map[$_]$_{$*_, $k: $_, $*_, $k: $_, $*_}`).
 		Where(m["k"].Pure).
-		Report(`suspicious duplicate key $k`)
+		Report(`suspicious duplicate key $k`).
+		At(m["k"])
 
 	m.Match(`$dst = append($x, $a); $dst = append($x, $b)`).
 		Report(`$dst=append($x,$a,$b) is faster`)

--- a/dsl/fluent/dsl.go
+++ b/dsl/fluent/dsl.go
@@ -26,7 +26,15 @@ func (m Matcher) Where(cond bool) Matcher {
 // For every matched variable it's possible to interpolate
 // their printed representation into the message text with $<name>.
 // An entire match can be addressed with $$.
-func (Matcher) Report(message string) {}
+func (m Matcher) Report(message string) Matcher {
+	return m
+}
+
+// At binds the reported node to a named submatch.
+// If no explicit location is given, the outermost node ($$) is used.
+func (m Matcher) At(v Var) Matcher {
+	return m
+}
 
 // Var is a pattern variable that describes a named submatch.
 type Var struct {

--- a/ruleguard/gorule.go
+++ b/ruleguard/gorule.go
@@ -16,6 +16,7 @@ type goRule struct {
 	severity string
 	pat      *gogrep.Pattern
 	msg      string
+	location string
 	filters  map[string]submatchFilter
 }
 

--- a/ruleguard/runner.go
+++ b/ruleguard/runner.go
@@ -82,7 +82,11 @@ func (rr *rulesRunner) handleMatch(rule goRule, m gogrep.MatchData) bool {
 		prefix = rule.severity + ": "
 	}
 	message := prefix + rr.renderMessage(rule.msg, m.Node, m.Values)
-	rr.ctx.Report(m.Node, message)
+	node := m.Node
+	if rule.location != "" {
+		node = m.Values[rule.location]
+	}
+	rr.ctx.Report(node, message)
 	return true
 }
 


### PR DESCRIPTION
Can be called after Report() to specify
which named submatch should be a report target.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>