### PR TITLE
rules.go: detect error used as underlying type for a named type

### DIFF
--- a/analyzer/testdata/src/extra/file.go
+++ b/analyzer/testdata/src/extra/file.go
@@ -165,3 +165,5 @@ func testCtx(ctx context.Context) error {
 
 	return nil
 }
+
+type errDontLog error // want `error as underlying type is probably a mistake`

--- a/analyzer/testdata/src/extra/rules.go
+++ b/analyzer/testdata/src/extra/rules.go
@@ -61,4 +61,9 @@ func _(m fluent.Matcher) {
 	m.Match(`select {case <-$ctx.Done(): return $ctx.Err(); default:}`).
 		Where(m["ctx"].Type.Is(`context.Context`)).
 		Suggest(`if err := $ctx.Err(); err != nil { return err }`)
+
+	// See https://twitter.com/dvyukov/status/1174698980208513024
+	m.Match(`type $x error`).
+		Report(`error as underlying type is probably a mistake`).
+		Suggest(`type $x struct { error }`)
 }

--- a/rules.go
+++ b/rules.go
@@ -26,6 +26,11 @@ func _(m fluent.Matcher) {
 	m.Match(`json.NewDecoder($_).Decode($_)`).
 		Report(`this json.Decoder usage is erroneous`)
 
+	// See https://twitter.com/dvyukov/status/1174698980208513024
+	m.Match(`type $x error`).
+		Report(`error as underlying type is probably a mistake`).
+		Suggest(`type $x struct { error }`)
+
 	m.Match(`time.Duration($x) * time.Second`).
 		Where(m["x"].Const).
 		Suggest(`$x * time.Second`)


### PR DESCRIPTION
It also supports a simple fix that embeds an error value inside a struct
as it was done in https://github.com/google/syzkaller/commit/b4680d8341733f48295ccf188f109cf69027a3f9

Signed-off-by: Iskander (Alex) Sharipov <quasilyte@gmail.com>