### PR TITLE
ruleguard: support builtin type aliases (rune, byte)

### DIFF
--- a/analyzer/testdata/src/extra/file.go
+++ b/analyzer/testdata/src/extra/file.go
@@ -16,6 +16,11 @@ type canStringer struct{}
 
 func (canStringer) String() string { return "" }
 
+func testRedundantCast(b byte, ch rune) {
+	sink = byte(b)  // want `\Qsuggestion: b`
+	sink = rune(ch) // want `\Qsuggestion: ch`
+}
+
 func testRedundantSprint(s canStringer) {
 	{
 		_ = fmt.Sprint(s) // want `\Qsuggestion: s.String()`

--- a/analyzer/testdata/src/extra/rules.go
+++ b/analyzer/testdata/src/extra/rules.go
@@ -132,4 +132,7 @@ func _(m fluent.Matcher) {
 	m.Match(`fmt.Sprintf("%s%s", $a, $b)`).
 		Where(m["a"].Type.Is(`string`) && m["b"].Type.Is(`string`)).
 		Suggest(`$a+$b`)
+
+	m.Match(`byte($x)`).Where(m["x"].Type.Is("byte")).Suggest(`$x`)
+	m.Match(`rune($x)`).Where(m["x"].Type.Is("rune")).Suggest(`$x`)
 }

--- a/ruleguard/typematch/typematch.go
+++ b/ruleguard/typematch/typematch.go
@@ -109,6 +109,10 @@ var (
 		"string":     types.Typ[types.String],
 
 		"error": types.Universe.Lookup("error").Type(),
+
+		// Aliases.
+		"byte": types.Typ[types.Uint8],
+		"rune": types.Typ[types.Int32],
 	}
 
 	efaceType = types.NewInterfaceType(nil, nil)

--- a/ruleguard/typematch/typematch_test.go
+++ b/ruleguard/typematch/typematch_test.go
@@ -9,6 +9,8 @@ import (
 var (
 	typeInt    = types.Typ[types.Int]
 	typeString = types.Typ[types.String]
+	typeInt32  = types.Typ[types.Int32]
+	typeUint8  = types.Typ[types.Uint8]
 
 	testContext = &Context{
 		Itab: NewImportsTab(map[string]string{
@@ -65,6 +67,11 @@ func TestIdentical(t *testing.T) {
 		{`io.Reader`, namedType2("io", "Reader")},
 		{`syntax.Regexp`, namedType2("regexp/syntax", "Regexp")},
 		{`*syntax.Regexp`, types.NewPointer(namedType2("regexp/syntax", "Regexp"))},
+
+		{`byte`, typeUint8},
+		{`rune`, typeInt32},
+		{`[]rune`, types.NewSlice(typeInt32)},
+		{`[8]byte`, types.NewArray(typeUint8, 8)},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Whenever rune is used, int32 is implied.
Whenever byte is used, uint8 is implied.

Fixes #58

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>