### PR TITLE
ruleguard/typematch: handle builtin types in opNamed correctly

### DIFF
--- a/analyzer/testdata/src/filtertest/f1.go
+++ b/analyzer/testdata/src/filtertest/f1.go
@@ -1,5 +1,7 @@
 package filtertest
 
+import "time"
+
 type implementsAll struct{}
 
 func (implementsAll) Read([]byte) (int, error) { return 0, nil }
@@ -46,6 +48,15 @@ func detectType() {
 	typeTest([100]byte{}, "size!=100")
 	typeTest([105]byte{}, "size!=100") // want `YES`
 	typeTest([10]byte{}, "size!=100")  // want `YES`
+
+	var time1, time2 time.Time
+	var err error
+	typeTest(time1 == time2, "time==time") // want `YES`
+	typeTest(err == nil, "time==time")
+	typeTest(nil == err, "time==time")
+	typeTest(time1 != time2, "time!=time") // want `YES`
+	typeTest(err != nil, "time!=time")
+	typeTest(nil != err, "time!=time")
 }
 
 func detectPure(x int) {

--- a/analyzer/testdata/src/filtertest/rules.go
+++ b/analyzer/testdata/src/filtertest/rules.go
@@ -47,6 +47,9 @@ func _(m fluent.Matcher) {
 	m.Match(`typeTest($x, "size==100")`).Where(m["x"].Type.Size == 100).Report(`YES`)
 	m.Match(`typeTest($x, "size!=100")`).Where(m["x"].Type.Size != 100).Report(`YES`)
 
+	m.Match(`typeTest($t0 == $t1, "time==time")`).Where(m["t0"].Type.Is("time.Time")).Report(`YES`)
+	m.Match(`typeTest($t0 != $t1, "time!=time")`).Where(m["t1"].Type.Is("time.Time")).Report(`YES`)
+
 	m.Match(`pureTest($x)`).
 		Where(m["x"].Pure).
 		Report("pure")

--- a/ruleguard/typematch/typematch.go
+++ b/ruleguard/typematch/typematch.go
@@ -322,9 +322,16 @@ func (p *Pattern) matchIdentical(sub *pattern, typ types.Type) bool {
 		if !ok {
 			return false
 		}
+		obj := typ.Obj()
+		pkg := obj.Pkg()
+		// pkg can be nil for builtin named types.
+		// There is no point in checking anything else as we never
+		// generate the opNamed for such types.
+		if pkg == nil {
+			return false
+		}
 		pkgPath := sub.value.([2]string)[0]
 		typeName := sub.value.([2]string)[1]
-		obj := typ.Obj()
 		return obj.Pkg().Path() == pkgPath && typeName == obj.Name()
 
 	default:


### PR DESCRIPTION
"error" type is *types.Named, but it doesn't have the Package.
This can lead to a nil pointer dereference if we don't handle that case.

Since we never emit opNamed for builtin types, we can fix the
problem by doing an early "return false" for types without a package.

Fixes #61

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>