### PR TITLE
all: added support for multi-file rule sets

### DIFF
--- a/ruleguard/gorule.go
+++ b/ruleguard/gorule.go
@@ -13,6 +13,7 @@ type scopedGoRuleSet struct {
 }
 
 type goRule struct {
+	filename   string
 	severity   string
 	pat        *gogrep.Pattern
 	msg        string

--- a/ruleguard/merge.go
+++ b/ruleguard/merge.go
@@ -1,0 +1,24 @@
+package ruleguard
+
+func mergeRuleSets(toMerge []*GoRuleSet) *GoRuleSet {
+	out := &GoRuleSet{
+		local:     &scopedGoRuleSet{},
+		universal: &scopedGoRuleSet{},
+	}
+
+	for _, x := range toMerge {
+		out.local = appendScopedRuleSet(out.local, x.local)
+		out.universal = appendScopedRuleSet(out.universal, x.universal)
+	}
+
+	return out
+}
+
+func appendScopedRuleSet(dst, src *scopedGoRuleSet) *scopedGoRuleSet {
+	dst.uncategorized = append(dst.uncategorized, src.uncategorized...)
+	for cat, rules := range src.rulesByCategory {
+		dst.rulesByCategory[cat] = append(dst.rulesByCategory[cat], rules...)
+		dst.categorizedNum += len(rules)
+	}
+	return dst
+}

--- a/ruleguard/parser.go
+++ b/ruleguard/parser.go
@@ -18,9 +18,10 @@ import (
 )
 
 type rulesParser struct {
-	fset  *token.FileSet
-	res   *GoRuleSet
-	types *types.Info
+	filename string
+	fset     *token.FileSet
+	res      *GoRuleSet
+	types    *types.Info
 
 	itab        *typematch.ImportsTab
 	dslImporter types.Importer
@@ -183,6 +184,7 @@ func newRulesParser() *rulesParser {
 }
 
 func (p *rulesParser) ParseFile(filename string, fset *token.FileSet, r io.Reader) (*GoRuleSet, error) {
+	p.filename = filename
 	p.fset = fset
 	p.res = &GoRuleSet{
 		local:     &scopedGoRuleSet{},
@@ -319,7 +321,8 @@ func (p *rulesParser) parseRule(matcher string, call *ast.CallExpr) error {
 	dst := p.res.universal
 	filters := map[string]submatchFilter{}
 	proto := goRule{
-		filters: filters,
+		filename: p.filename,
+		filters:  filters,
 	}
 	var alternatives []string
 

--- a/ruleguard/ruleguard.go
+++ b/ruleguard/ruleguard.go
@@ -11,7 +11,7 @@ type Context struct {
 	Types  *types.Info
 	Sizes  types.Sizes
 	Fset   *token.FileSet
-	Report func(n ast.Node, msg string, s *Suggestion)
+	Report func(rule GoRuleInfo, n ast.Node, msg string, s *Suggestion)
 	Pkg    *types.Package
 }
 
@@ -30,7 +30,16 @@ func RunRules(ctx *Context, f *ast.File, rules *GoRuleSet) error {
 	return newRulesRunner(ctx, rules).run(f)
 }
 
+type GoRuleInfo struct {
+	// Filename is a file that defined this rule.
+	Filename string
+}
+
 type GoRuleSet struct {
 	universal *scopedGoRuleSet
 	local     *scopedGoRuleSet
+}
+
+func MergeRuleSets(toMerge []*GoRuleSet) *GoRuleSet {
+	return mergeRuleSets(toMerge)
 }

--- a/ruleguard/runner.go
+++ b/ruleguard/runner.go
@@ -158,7 +158,10 @@ func (rr *rulesRunner) handleMatch(rule goRule, m gogrep.MatchData) bool {
 			To:          node.End(),
 		}
 	}
-	rr.ctx.Report(node, message, suggestion)
+	info := GoRuleInfo{
+		Filename: rule.filename,
+	}
+	rr.ctx.Report(info, node, message, suggestion)
 	return true
 }
 


### PR DESCRIPTION
-rules flag becomes a comma-separated list of rule filenames.
If only one filename is provided, no effects will be noticed.
If more than one filenames are provided, they are merged
into one rule set that combines all rules.

To avoid information loss, we pass GoRuleInfo object to the
Report() callback, so the application can figure out which
file provided a rule that triggered.

As a demonstration, cmd/ruleguard now appends the "(filename)"
suffix to the warning messages when executed with multiple rule files.

The new ruleguard.MergeRuleSets() function can be used in
integrations like https://github.com/go-critic/go-critic/pull/947

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>