### PR TITLE
Truncate too long output instead of using key

### DIFF
--- a/analyzer/testdata/src/extra/file.go
+++ b/analyzer/testdata/src/extra/file.go
@@ -326,6 +326,6 @@ func testYodaExpr() {
 	if nil != clusterContext.PostInstallData.CoreDNSUpdateFunction { // want `\Qsuggestion: clusterContext.PostInstallData.CoreDNSUpdateFunction != nil`
 	}
 	// This is far too long, so it's shortened in the output.
-	if nil != clusterContext.PostInstallData.AnotherNestedStruct.DeeplyNestedField { // want `\Qsuggestion: $s != nil`
+	if nil != clusterContext.PostInstallData.AnotherNestedStruct.DeeplyNestedField { // want `\Qsuggestion: clusterContext.PostInstallData.AnotherNestedStruct.DeeplyNes... != nil`
 	}
 }

--- a/ruleguard/runner.go
+++ b/ruleguard/runner.go
@@ -189,7 +189,7 @@ func (rr *rulesRunner) renderMessage(msg string, n ast.Node, nodes map[string]as
 		// Don't interpolate strings that are too long.
 		var replacement string
 		if truncate && buf.Len() > 60 {
-			replacement = key
+			replacement = string([]rune(buf.String())[:60]) + "..."
 		} else {
 			replacement = buf.String()
 		}


### PR DESCRIPTION
When outputing results the current behavior is to use the key in the
output if the identifier would be too long for example:
"$f != nil"

This instead truncates the value and adds elisis as follows:

"ThisIsAReallyLongIdentifierThatWillBeTruncatedInsteadOfReje... != nil"

This output is more friendly.

Addresses #70