### PR TITLE
ruleguard: unquote the pattern string properly

### DIFF
--- a/analyzer/testdata/src/regression/issue72.go
+++ b/analyzer/testdata/src/regression/issue72.go
@@ -1,0 +1,10 @@
+package regression
+
+import "fmt"
+
+func testIssue72() {
+	_ = fmt.Sprintf("%s<%s>", "name", "email@domain.example")      // want `\Quse net/mail Address.String() instead of fmt.Sprintf()`
+	_ = fmt.Sprintf("\"%s\" <%s>", "name", "email@domain.example") // want `\Quse net/mail Address.String() instead of fmt.Sprintf()`
+	_ = fmt.Sprintf(`"%s" <%s>`, "name", "email@domain.example")   // want `\Quse net/mail Address.String() instead of fmt.Sprintf()`
+	_ = fmt.Sprintf(`"%s"<%s>`, "name", "email@domain.example")    // want `\Quse net/mail Address.String() instead of fmt.Sprintf()`
+}

--- a/analyzer/testdata/src/regression/rules.go
+++ b/analyzer/testdata/src/regression/rules.go
@@ -10,3 +10,12 @@ func issue68(m fluent.Matcher) {
 	m.Match(`func $_($_ *testing.T) { $p; $*_ }`).Where(m["p"].Text != "t.Parallel()").Report(`Not a parallel test`)
 	m.Match(`func $_($_ *testing.T) { $p; $*_ }`).Where(m["p"].Text == "t.Parallel()").Report(`Parallel test`)
 }
+
+func issue72(m fluent.Matcher) {
+	m.Match("fmt.Sprintf(`\"%s\" <%s>`, $name, $email)",
+		"fmt.Sprintf(`\"%s\"<%s>`, $name, $email)",
+		`fmt.Sprintf("\"%s\" <%s>", $name, $email)`,
+		`fmt.Sprintf("\"%s\"<%s>", $name, $email)`,
+		`fmt.Sprintf("%s<%s>", $name, $email)`).
+		Report("use net/mail Address.String() instead of fmt.Sprintf()")
+}

--- a/ruleguard/parser.go
+++ b/ruleguard/parser.go
@@ -603,7 +603,11 @@ func (p *rulesParser) toStringValue(x ast.Node) (string, bool) {
 		if x.Kind != token.STRING {
 			return "", false
 		}
-		return unquoteNode(x), true
+		s, err := strconv.Unquote(x.Value)
+		if err != nil {
+			return "", false
+		}
+		return s, true
 	case ast.Expr:
 		typ, ok := p.types.Types[x]
 		if !ok || typ.Type.String() != "string" {

--- a/ruleguard/utils.go
+++ b/ruleguard/utils.go
@@ -10,10 +10,6 @@ import (
 	"strings"
 )
 
-func unquoteNode(lit *ast.BasicLit) string {
-	return lit.Value[1 : len(lit.Value)-1]
-}
-
 func sprintNode(fset *token.FileSet, n ast.Node) string {
 	if fset == nil {
 		fset = token.NewFileSet()


### PR DESCRIPTION
Instead of just dropping the both quotes, do the
actual unquoting that may involve some string interpretation
in case of the "-literals.

strconv.Unquote() is the right way to do it.

Refs #72

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>