### PR TITLE
Parsing parenthesized expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.vscode

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/quasilyte/go-ruleguard
 
 go 1.15
 
-require golang.org/x/tools v0.0.0-20200812195022-5ae4c3c160a0
+require (
+	github.com/stretchr/testify v1.6.1
+	golang.org/x/tools v0.0.0-20200812195022-5ae4c3c160a0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -20,3 +27,6 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/ruleguard/parser.go
+++ b/ruleguard/parser.go
@@ -412,7 +412,6 @@ func (p *rulesParser) walkFilter(dst map[string]submatchFilter, e ast.Expr, nega
 			return x(s) && y(s)
 		}
 	}
-
 	switch e := e.(type) {
 	case *ast.UnaryExpr:
 		if e.Op == token.NOT {
@@ -449,6 +448,8 @@ func (p *rulesParser) walkFilter(dst map[string]submatchFilter, e ast.Expr, nega
 				return nil
 			}
 		}
+	case *ast.ParenExpr:
+		return p.walkFilter(dst, e.X, negate)
 	}
 
 	// TODO(quasilyte): refactor and extend.

--- a/ruleguard/parser_test.go
+++ b/ruleguard/parser_test.go
@@ -1,0 +1,42 @@
+package ruleguard
+
+import (
+	"bytes"
+	"go/token"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatchParenthesizedExpr(t *testing.T) {
+	p := newRulesParser()
+	fset := token.NewFileSet()
+	rs, err := p.ParseFile("", fset, bytes.NewBufferString(testRules))
+	require.NoError(t, err)
+	rl := rs.universal.rulesByCategory[nodeCallExpr]
+	require.Equal(t, 1, len(rl))
+	_, ok := rl[0].filters["a"]
+	require.True(t, ok)
+}
+
+const testRules = `
+// +build ignore
+
+package gorules
+
+import (
+	"github.com/quasilyte/go-ruleguard/dsl/fluent"
+)
+
+func _(m fluent.Matcher) {
+	
+	// rule for matching github.com/Masterminds/squirrel.SelectBuilder.Where misuses
+	m.Match("$_.Where($a,$_)").Where(
+		!(m["a"].Type.Is("string") && m["a"].Text.Matches("\\?")) &&
+			!m["a"].Type.Is("map[string]interface{}"),
+	).
+		Report("squirrel.SelectBuilder.Where second parameter is ignored when first cannot " +
+			"be transformed to a string containing ? placeholder. " +
+			"See https://pkg.go.dev/github.com/Masterminds/squirrel?tab=doc#SelectBuilder.Where")
+}
+`


### PR DESCRIPTION
## Problem
Parsing a rule with the form `(a && b) && c` fails because the there's no way of handling parenthesized expressions

## Solution
- Adding a case statement to the parser so it handles correctly a parenthesized expression.
- Testing with a particular example.