### PR TITLE
ruleguard/typematch: implement func type patterns

### DIFF
--- a/analyzer/testdata/src/filtertest/f1.go
+++ b/analyzer/testdata/src/filtertest/f1.go
@@ -57,6 +57,23 @@ func detectType() {
 	typeTest(time1 != time2, "time!=time") // want `YES`
 	typeTest(err != nil, "time!=time")
 	typeTest(nil != err, "time!=time")
+
+	intFunc := func() int { return 10 }
+	intToIntFunc := func(x int) int { return x }
+	typeTest(intFunc(), "func() int")                 // want `YES`
+	typeTest(func() int { return 0 }(), "func() int") // want `YES`
+	typeTest(func() string { return "" }(), "func() int")
+	typeTest(intToIntFunc(1), "func() int")
+
+	typeTest(intToIntFunc(2), "func(int) int") // want `YES`
+	typeTest(intToIntFunc, "func(int) int")
+	typeTest(intFunc, "func(int) int")
+
+	var v implementsAll
+	typeTest(v.String(), "func() string") // want `YES`
+	typeTest(implementsAll.String(v), "func() string")
+	typeTest(implementsAll.String, "func() string")
+
 }
 
 func detectPure(x int) {

--- a/analyzer/testdata/src/filtertest/rules.go
+++ b/analyzer/testdata/src/filtertest/rules.go
@@ -47,6 +47,18 @@ func _(m fluent.Matcher) {
 	m.Match(`typeTest($x, "size==100")`).Where(m["x"].Type.Size == 100).Report(`YES`)
 	m.Match(`typeTest($x, "size!=100")`).Where(m["x"].Type.Size != 100).Report(`YES`)
 
+	m.Match(`typeTest($x(), "func() int")`).
+		Where(m["x"].Type.Is("func() int")).
+		Report(`YES`)
+
+	m.Match(`typeTest($x($*_), "func(int) int")`).
+		Where(m["x"].Type.Is("func(int) int")).
+		Report(`YES`)
+
+	m.Match(`typeTest($x(), "func() string")`).
+		Where(m["x"].Type.Is("func() string")).
+		Report(`YES`)
+
 	m.Match(`typeTest($t0 == $t1, "time==time")`).Where(m["t0"].Type.Is("time.Time")).Report(`YES`)
 	m.Match(`typeTest($t0 != $t1, "time!=time")`).Where(m["t1"].Type.Is("time.Time")).Report(`YES`)
 


### PR DESCRIPTION
Now it's possible to use func types in ExprType.Is-like patterns
inside Where() clauses.

Function type patterns should not use param names.

	This is illegal: func(x int) (res string, err error)
	This is legal:   func(int) (string, error)

It's possible to use meta types:

	func($t, $t) int - function of 2 same args returning int
	func() $t - function of 0 args that returns anything
	func($t) $t - function of 1 arg that returns a value of the same type
	func($t1) $t2 - function of 1 arg returning 1 result

Refs #80

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>