### PR TITLE
rules.go: add badLock rule

### DIFF
--- a/analyzer/testdata/src/extra/negative_tests.go
+++ b/analyzer/testdata/src/extra/negative_tests.go
@@ -1,0 +1,37 @@
+package extra
+
+import "sync"
+
+func deferredUnlock(mu *sync.Mutex, op func()) {
+	mu.Lock()
+	defer mu.Unlock()
+	op()
+}
+
+func goodUnlock(mu *sync.RWMutex, op func()) {
+	mu.Lock()
+	defer mu.Unlock()
+	op()
+}
+
+func goodRUnlock(mu *sync.RWMutex, op func()) {
+	mu.RLock()
+	defer mu.RUnlock()
+	op()
+}
+
+func differentMutexes(mu1, mu2 *sync.RWMutex, op func()) {
+	{
+		mu2.RLock()
+		mu1.Lock()
+		mu2.RUnlock()
+		mu1.Unlock()
+	}
+
+	{
+		mu1.Lock()
+		mu2.Lock()
+		mu1.Unlock()
+		mu2.Unlock()
+	}
+}

--- a/analyzer/testdata/src/extra/rules.go
+++ b/analyzer/testdata/src/extra/rules.go
@@ -140,4 +140,7 @@ func _(m fluent.Matcher) {
 	m.Match(`rune($x)`).Where(m["x"].Type.Is("rune")).Suggest(`$x`)
 
 	m.Match(`nil != $s`).Where(!m["s"].Const).Suggest(`$s != nil`)
+
+	m.Match(`$mu.Lock(); defer $mu.RUnlock()`).Report(`maybe $mu.RLock() was intended?`)
+	m.Match(`$mu.RLock(); defer $mu.Unlock()`).Report(`maybe $mu.Lock() was intended?`)
 }

--- a/rules.go
+++ b/rules.go
@@ -393,6 +393,11 @@ func gocriticFlagDeref(m fluent.Matcher) {
 		Report(`immediate deref in $$ is most likely an error`)
 }
 
+func gocriticBadLock(m fluent.Matcher) {
+	m.Match(`$mu.Lock(); defer $mu.RUnlock()`).Report(`maybe $mu.RLock() was intended?`)
+	m.Match(`$mu.RLock(); defer $mu.Unlock()`).Report(`maybe $mu.Lock() was intended?`)
+}
+
 func reviveBoolLiteralInExpr(m fluent.Matcher) {
 	m.Match(`$x == true`,
 		`$x != true`,


### PR DESCRIPTION
Ported from the go-critic linter.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>