### PR TITLE
ruleguard/typematch: implement struct type pattern matching

### DIFF
--- a/ruleguard/typematch/typematch.go
+++ b/ruleguard/typematch/typematch.go
@@ -16,11 +16,14 @@ const (
 	opBuiltinType patternOp = iota
 	opPointer
 	opVar
+	opVarSeq
 	opSlice
 	opArray
 	opMap
 	opChan
 	opFunc
+	opStructNoSeq
+	opStruct
 	opNamed
 )
 
@@ -71,8 +74,14 @@ type Context struct {
 	Itab *ImportsTab
 }
 
+const (
+	varPrefix    = `ᐸvarᐳ`
+	varSeqPrefix = `ᐸvar_seqᐳ`
+)
+
 func Parse(ctx *Context, s string) (*Pattern, error) {
-	noDollars := strings.ReplaceAll(s, "$", "__")
+	noDollars := strings.ReplaceAll(s, "$*", varSeqPrefix)
+	noDollars = strings.ReplaceAll(noDollars, "$", varPrefix)
 	n, err := parser.ParseExpr(noDollars)
 	if err != nil {
 		return nil, err
@@ -126,9 +135,16 @@ func parseExpr(ctx *Context, e ast.Expr) *pattern {
 		if ok {
 			return &pattern{op: opBuiltinType, value: basic}
 		}
-		if strings.HasPrefix(e.Name, "__") {
-			name := strings.TrimPrefix(e.Name, "__")
+		if strings.HasPrefix(e.Name, varPrefix) {
+			name := strings.TrimPrefix(e.Name, varPrefix)
 			return &pattern{op: opVar, value: name}
+		}
+		if strings.HasPrefix(e.Name, varSeqPrefix) {
+			name := strings.TrimPrefix(e.Name, varSeqPrefix)
+			// Only unnamed seq are supported right now.
+			if name == "_" {
+				return &pattern{op: opVarSeq, value: name}
+			}
 		}
 
 	case *ast.SelectorExpr:
@@ -160,8 +176,8 @@ func parseExpr(ctx *Context, e ast.Expr) *pattern {
 				subs: []*pattern{elem},
 			}
 		}
-		if id, ok := e.Len.(*ast.Ident); ok && strings.HasPrefix(id.Name, "__") {
-			name := strings.TrimPrefix(id.Name, "__")
+		if id, ok := e.Len.(*ast.Ident); ok && strings.HasPrefix(id.Name, varPrefix) {
+			name := strings.TrimPrefix(id.Name, varPrefix)
 			return &pattern{
 				op:    opArray,
 				value: name,
@@ -254,6 +270,31 @@ func parseExpr(ctx *Context, e ast.Expr) *pattern {
 			subs:  append(params, results...),
 		}
 
+	case *ast.StructType:
+		hasSeq := false
+		members := make([]*pattern, 0, len(e.Fields.List))
+		for _, field := range e.Fields.List {
+			p := parseExpr(ctx, field.Type)
+			if p == nil {
+				return nil
+			}
+			if len(field.Names) != 0 {
+				return nil
+			}
+			if p.op == opVarSeq {
+				hasSeq = true
+			}
+			members = append(members, p)
+		}
+		op := opStructNoSeq
+		if hasSeq {
+			op = opStruct
+		}
+		return &pattern{
+			op:   op,
+			subs: members,
+		}
+
 	case *ast.InterfaceType:
 		if len(e.Methods.List) == 0 {
 			return &pattern{op: opBuiltinType, value: efaceType}
@@ -275,6 +316,54 @@ func (p *Pattern) reset() {
 	if len(p.typeMatches) != 0 {
 		p.typeMatches = map[string]types.Type{}
 	}
+}
+
+func (p *Pattern) matchIdenticalFielder(subs []*pattern, f fielder) bool {
+	// TODO: do backtracking.
+
+	numFields := f.NumFields()
+	fieldsMatched := 0
+
+	if len(subs) == 0 && numFields != 0 {
+		return false
+	}
+
+	matchAny := false
+
+	i := 0
+	for i < len(subs) {
+		pat := subs[i]
+
+		if pat.op == opVarSeq {
+			matchAny = true
+		}
+
+		fieldsLeft := numFields - fieldsMatched
+		if matchAny {
+			switch {
+			// "Nothing left to match" stop condition.
+			case fieldsLeft == 0:
+				matchAny = false
+				i++
+			// Lookahead for non-greedy matching.
+			case i+1 < len(subs) && p.matchIdentical(subs[i+1], f.Field(fieldsMatched).Type()):
+				matchAny = false
+				i += 2
+				fieldsMatched++
+			default:
+				fieldsMatched++
+			}
+			continue
+		}
+
+		if fieldsLeft == 0 || !p.matchIdentical(pat, f.Field(fieldsMatched).Type()) {
+			return false
+		}
+		i++
+		fieldsMatched++
+	}
+
+	return numFields == fieldsMatched
 }
 
 func (p *Pattern) matchIdentical(sub *pattern, typ types.Type) bool {
@@ -394,7 +483,37 @@ func (p *Pattern) matchIdentical(sub *pattern, typ types.Type) bool {
 		}
 		return true
 
+	case opStructNoSeq:
+		typ, ok := typ.(*types.Struct)
+		if !ok {
+			return false
+		}
+		if typ.NumFields() != len(sub.subs) {
+			return false
+		}
+		for i, member := range sub.subs {
+			if !p.matchIdentical(member, typ.Field(i).Type()) {
+				return false
+			}
+		}
+		return true
+
+	case opStruct:
+		typ, ok := typ.(*types.Struct)
+		if !ok {
+			return false
+		}
+		if !p.matchIdenticalFielder(sub.subs, typ) {
+			return false
+		}
+		return true
+
 	default:
 		return false
 	}
+}
+
+type fielder interface {
+	Field(i int) *types.Var
+	NumFields() int
 }


### PR DESCRIPTION
	struct{$*_} - arbitrary struct
	struct{$_; $_} - struct of any 2 fields
	struct{$x; $x} - struct of 2 fields of type $x
	struct{$*_; $x} - struct that ends with $x-typed field
	struct{$x; $*_} - struct that starts with $x-typed field
	struct{$*_; $x; $*_} - struct that contains $x-typed field

This is not a direct solution for https://twitter.com/dgryski/status/1317245210041012224,
but it makes us get a little closer to it.

There are several interpretations of Type.Contains() and we need
to decide what should be traversed and whatnot (and how deep).

Until we decide on the exact Type.Contains() semantics, struct
type pattern matching can be a temporary solution to this problem.

I'll add analyzer tests later to see whether it really can be
used in the requested context. I would expect that we need
things like Type.Underlying(), etc. to make it work correctly.
But that's a different story.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>