### PR TITLE
add another test for underlying type filter

### DIFF
--- a/analyzer/testdata/src/filtertest/f1.go
+++ b/analyzer/testdata/src/filtertest/f1.go
@@ -20,9 +20,12 @@ func detectType() {
 			x time.Time
 		}
 		var bar withNamedTime
+		type indirectFoo1 withNamedTime
+		type indirectFoo2 indirectFoo1
 		typeTest(withNamedTime{}, "contains time.Time") // want `YES`
 		typeTest(foo, "contains time.Time")             // want `YES`
 		typeTest(bar, "contains time.Time")             // want `YES`
+		typeTest(indirectFoo2{}, "contains time.Time")  // want `YES`
 	}
 
 	{


### PR DESCRIPTION
Undelying type definition is recursive, so calling
Underlying() is enough to resolve the entire type chain.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>