### PR TITLE
Remote configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,10 @@ To learn more, check out the documentation and/or the source code.
 
 ## Ready to use rules
 
-There is the list of open source rules you can use in your project:
+There is the list of open-source rules you can use in your project:
 
 * [go-ruleguard/rules.go](https://github.com/quasilyte/go-ruleguard/blob/master/rules.go)
-* [gsemgrep-go/ruleguard.rules.go](https://github.com/dgryski/semgrep-go/blob/master/ruleguard.rules.go)
+* [semgrep-go/ruleguard.rules.go](https://github.com/dgryski/semgrep-go/blob/master/ruleguard.rules.go)
 * [go-critic/rules.go](https://github.com/go-critic/go-critic/blob/master/rules.go)
 
 ## Extra references

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ You write the rules, `ruleguard` checks whether they are satisfied.
 * Diagnostics are written in a declarative way.
 * [Quickfix](docs/gorules.md#suggestions-quickfix-support) actions support.
 * Powerful match filtering features, like expression [type pattern matching](docs/gorules.md#type-pattern-matching).
+* Remote configuration. Reuse rules between projects, use ruleguard as zero-configuration linter.
 
-`ruleguard` comes with [rules.go](rules.go) file that can be used as a foundation to write your own rules file.
+`ruleguard` comes with [rules.go](rules.go) file that can be used as linter or as an example.
 
 It can also be easily embedded into other static analyzers. [go-critic](https://github.com/go-critic/go-critic) can be used as an example.
 
@@ -43,16 +44,49 @@ Usage: ruleguard [-flag] [package]
 
 Flags:
   -rules string
-    	path to a rules.go file
+        comma-separated list of gorule file paths or URLs
   -e string
-    	execute a single rule from a given string
+        execute a single rule from a given string
   -fix
-    	apply all suggested fixes
+        apply all suggested fixes
   -c int
-    	display offending line with this many lines of context (default -1)
+        display offending line with this many lines of context (default -1)
   -json
-    	emit JSON output
+        emit JSON output
 ```
+
+
+Create a test `example.go` target file:
+
+```go
+package main
+
+func main() {
+	var v1, v2 int
+	println(!(v1 != v2))
+	println(!(v1 == v2))
+	if v1 == 0 && v1 == 0 {
+		println("hello, world!")
+	}
+}
+```
+
+Run `ruleguard` on that target file:
+
+```bash
+$ ruleguard \
+    -rules https://raw.githubusercontent.com/quasilyte/go-ruleguard/master/rules.go \
+    -fix example.go
+example.go:5:10: suggestion: v1 == v2
+example.go:6:10: suggestion: v1 != v2
+example.go:7:5: suspicious identical LHS and RHS
+```
+
+The `-rules` option can be a path to a local file with rules, an URL, or comma-separated list of paths and URLs in any combination.
+
+Since we ran `ruleguard` with `-fix` argument, both **suggested** changes are applied to `example.go`.
+
+## Using custom rules
 
 Create a test `example.rules.go` file:
 
@@ -74,21 +108,6 @@ func _(m fluent.Matcher) {
 }
 ```
 
-Create a test `example.go` target file:
-
-```go
-package main
-
-func main() {
-	var v1, v2 int
-	println(!(v1 != v2))
-	println(!(v1 == v2))
-	if v1 == 0 && v1 == 0 {
-		println("hello, world!")
-	}
-}
-```
-
 Run `ruleguard` on that target file:
 
 ```bash
@@ -97,8 +116,6 @@ example.go:5:10: hint: suggested: v1 == v2
 example.go:6:10: hint: suggested: v1 != v2
 example.go:7:5: error: suspicious identical LHS and RHS
 ```
-
-Since we ran `ruleguard` with `-fix` argument, both **suggested** changes are applied to `example.go`.
 
 There is also a `-e` mode that is useful during pattern debugging:
 
@@ -109,10 +126,10 @@ example.go:5:10: !(v1 != v2)
 
 It automatically inserts `Report("$$")` into the specified pattern.
 
-## How does it work?
+## How it works
 
-`ruleguard` parses [gorules](docs/gorules.md) (e.g. `rules.go`) during the start to load the rule set.  
-Loaded rules are then used to check the specified targets (Go files, packages).  
+`ruleguard` parses [gorules](docs/gorules.md) (e.g. `rules.go`) during the start to load the rule set.
+Loaded rules are then used to check the specified targets (Go files, packages).
 The `rules.go` file itself is never compiled, nor executed.
 
 A `rules.go` file, as interpreted by a [`dsl/fluent`](https://godoc.org/github.com/quasilyte/go-ruleguard/dsl/fluent) API, is a set of functions that serve as a rule groups. Every function accepts a single [`fluent.Matcher`](https://godoc.org/github.com/quasilyte/go-ruleguard/dsl/fluent#Matcher) argument that is then used to define and configure rules inside the group.
@@ -131,6 +148,14 @@ To learn more, check out the documentation and/or the source code.
 * [dsl/fluent package](https://godoc.org/github.com/quasilyte/go-ruleguard/dsl/fluent) reference
 * [ruleguard package](https://godoc.org/github.com/quasilyte/go-ruleguard/ruleguard) reference
 * Introduction article: [EN](https://quasilyte.dev/blog/post/ruleguard/), [RU](https://habr.com/ru/post/481696/)
+
+## Ready to use rules
+
+There is the list of open source rules you can use in your project:
+
+* [go-ruleguard/rules.go](https://github.com/quasilyte/go-ruleguard/blob/master/rules.go)
+* [gsemgrep-go/ruleguard.rules.go](https://github.com/dgryski/semgrep-go/blob/master/ruleguard.rules.go)
+* [go-critic/rules.go](https://github.com/go-critic/go-critic/blob/master/rules.go)
 
 ## Extra references
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,6 @@ There is the list of open-source rules you can use in your project:
 
 * [go-ruleguard/rules.go](https://github.com/quasilyte/go-ruleguard/blob/master/rules.go)
 * [semgrep-go/ruleguard.rules.go](https://github.com/dgryski/semgrep-go/blob/master/ruleguard.rules.go)
-* [go-critic/rules.go](https://github.com/go-critic/go-critic/blob/master/rules.go)
 
 ## Extra references
 

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -1,12 +1,11 @@
 package analyzer
 
 import (
-	"bytes"
 	"fmt"
 	"go/ast"
 	"go/token"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -127,11 +126,11 @@ func readRules() (*parseRulesResult, error) {
 }
 
 func loadLocalConfig(filename string, fset *token.FileSet) (*ruleguard.GoRuleSet, error) {
-	data, err := ioutil.ReadFile(filename)
+	stream, err := os.Open(filename)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open file: %v", err)
 	}
-	rset, err := ruleguard.ParseRules(filename, fset, bytes.NewReader(data))
+	rset, err := ruleguard.ParseRules(filename, fset, stream)
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse rules: %v", err)
 	}

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -95,11 +95,7 @@ func readRules() (*parseRulesResult, error) {
 		var ruleSets []*ruleguard.GoRuleSet
 		for _, filename := range filenames {
 			filename = strings.TrimSpace(filename)
-			loader := loadLocalConfig
-			if strings.HasPrefix(filename, "http://") || strings.HasPrefix(filename, "https://") {
-				loader = loadRemoteConfig
-			}
-			rset, err := loader(filename, fset)
+			rset, err := loadConfig(filename, fset)
 			if err != nil {
 				return nil, fmt.Errorf("cannot read rules: %v", err)
 			}
@@ -123,6 +119,13 @@ func readRules() (*parseRulesResult, error) {
 	default:
 		return nil, fmt.Errorf("both -e and -rules flags are empty")
 	}
+}
+
+func loadConfig(filename string, fset *token.FileSet) (*ruleguard.GoRuleSet, error) {
+	if strings.HasPrefix(filename, "http://") || strings.HasPrefix(filename, "https://") {
+		return loadRemoteConfig(filename, fset)
+	}
+	return loadLocalConfig(filename, fset)
 }
 
 func loadLocalConfig(filename string, fset *token.FileSet) (*ruleguard.GoRuleSet, error) {

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -26,7 +26,7 @@ var (
 )
 
 func init() {
-	Analyzer.Flags.StringVar(&flagRules, "rules", "", "comma-separated list of gorule file paths")
+	Analyzer.Flags.StringVar(&flagRules, "rules", "", "comma-separated list of gorule file paths or URLs")
 	Analyzer.Flags.StringVar(&flagE, "e", "", "execute a single rule from a given string")
 }
 

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -91,20 +91,13 @@ func readRules() (*parseRulesResult, error) {
 
 	switch {
 	case flagRules != "":
-		if flagRules == "" {
-			return nil, fmt.Errorf("-rules values is empty")
-		}
 		filenames := strings.Split(flagRules, ",")
 		var ruleSets []*ruleguard.GoRuleSet
 		for _, filename := range filenames {
 			filename = strings.TrimSpace(filename)
-			data, err := ioutil.ReadFile(filename)
+			rset, err := loadLocalConfig(filename, fset)
 			if err != nil {
-				return nil, fmt.Errorf("read rules file: %v", err)
-			}
-			rset, err := ruleguard.ParseRules(filename, fset, bytes.NewReader(data))
-			if err != nil {
-				return nil, fmt.Errorf("parse rules file: %v", err)
+				return nil, err
 			}
 			ruleSets = append(ruleSets, rset)
 		}
@@ -126,4 +119,16 @@ func readRules() (*parseRulesResult, error) {
 	default:
 		return nil, fmt.Errorf("both -e and -rules flags are empty")
 	}
+}
+
+func loadLocalConfig(filename string, fset *token.FileSet) (*ruleguard.GoRuleSet, error) {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("read rules file: %v", err)
+	}
+	rset, err := ruleguard.ParseRules(filename, fset, bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("parse rules file: %v", err)
+	}
+	return rset, nil
 }

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -32,3 +32,25 @@ func TestAnalyzer(t *testing.T) {
 		})
 	}
 }
+
+func TestAnalyzer_Rules_RemoteConfig(t *testing.T) {
+	test := "rules"
+	url := "https://raw.githubusercontent.com/quasilyte/go-ruleguard/master/rules.go"
+	testdata := analysistest.TestData()
+	err := analyzer.Analyzer.Flags.Set("rules", url)
+	if err != nil {
+		t.Fatalf("set rules flag: %v", err)
+	}
+	analysistest.Run(t, testdata, analyzer.Analyzer, test)
+}
+
+func TestAnalyzer_Rules_LocalConfig(t *testing.T) {
+	test := "rules"
+	url := "../rules.go"
+	testdata := analysistest.TestData()
+	err := analyzer.Analyzer.Flags.Set("rules", url)
+	if err != nil {
+		t.Fatalf("set rules flag: %v", err)
+	}
+	analysistest.Run(t, testdata, analyzer.Analyzer, test)
+}

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -2,6 +2,9 @@ package analyzer_test
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path"
 	"testing"
 
 	"github.com/quasilyte/go-ruleguard/analyzer"
@@ -33,22 +36,34 @@ func TestAnalyzer(t *testing.T) {
 	}
 }
 
+type RulesHandler struct {
+	testdata string
+}
+
+func (h *RulesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	fpath := path.Join(h.testdata, "../../rules.go")
+	http.ServeFile(w, r, fpath)
+}
+
 func TestAnalyzer_Rules_RemoteConfig(t *testing.T) {
-	test := "rules"
-	url := "https://raw.githubusercontent.com/quasilyte/go-ruleguard/master/rules.go"
-	testdata := analysistest.TestData()
-	err := analyzer.Analyzer.Flags.Set("rules", url)
+	handler := RulesHandler{
+		testdata: analysistest.TestData(),
+	}
+	server := httptest.NewServer(&handler)
+	defer server.Close()
+
+	err := analyzer.Analyzer.Flags.Set("rules", server.URL)
 	if err != nil {
 		t.Fatalf("set rules flag: %v", err)
 	}
-	analysistest.Run(t, testdata, analyzer.Analyzer, test)
+	analysistest.Run(t, handler.testdata, analyzer.Analyzer, "rules")
 }
 
 func TestAnalyzer_Rules_LocalConfig(t *testing.T) {
 	test := "rules"
-	url := "../rules.go"
+	filename := "../rules.go"
 	testdata := analysistest.TestData()
-	err := analyzer.Analyzer.Flags.Set("rules", url)
+	err := analyzer.Analyzer.Flags.Set("rules", filename)
 	if err != nil {
 		t.Fatalf("set rules flag: %v", err)
 	}

--- a/analyzer/testdata/src/rules/main.go
+++ b/analyzer/testdata/src/rules/main.go
@@ -1,0 +1,8 @@
+// This package tests rules specified in `rules.go` of ruleguard itself.
+package main
+
+const () // want `empty const\(\) block`
+var ()   // want `empty var\(\) block`
+type ()  // want `empty type\(\) block`
+
+func main() {}

--- a/analyzer/testdata/src/rules/main.go
+++ b/analyzer/testdata/src/rules/main.go
@@ -1,8 +1,17 @@
 // This package tests rules specified in `rules.go` of ruleguard itself.
 package main
 
-const () // want `empty const\(\) block`
-var ()   // want `empty var\(\) block`
-type ()  // want `empty type\(\) block`
+import (
+	"fmt"
+	"os"
+)
 
-func main() {}
+const () // want `\Qempty const() block`
+var ()   // want `\Qempty var() block`
+type ()  // want `\Qempty type() block`
+
+func main() {
+	fmt.Fprint(os.Stdout, "hello")    // want `\Qsuggestion: fmt.Print("hello")`
+	fmt.Fprintln(os.Stdout, "hello")  // want `\Qsuggestion: fmt.Println("hello")`
+	fmt.Fprintf(os.Stdout, "%d", 123) // want `\Qsuggestion: fmt.Printf("%d", 123)`
+}


### PR DESCRIPTION
Allow `-rules` option to be a remote URL. This makes ruleguard suitable to be used as a zero-configuration linter.

[x] Tests included. They check a small file with a local and remote copy of `rules.go`. Later, this file should be duplicated to make it possible to test new checks that weren't introduced in the `master` branch yet.
[x] README updated.

Minor changes:

1. Remove redundant `if flagRules == ""`. The `if` body statement is unreachable.
1. Parse source code of `rules.go` right from the stream without reading it from the stream and then converting it into a stream again. It makes file reading a bit faster and memory-friendly.
1. Provide a short list of ready to use open-source rules.