### PR TITLE
fix bug in types.Identical rule

### DIFF
--- a/rules.go
+++ b/rules.go
@@ -268,7 +268,7 @@ func gocriticDupArg(m fluent.Matcher) {
 		`bytes.Replace($_, $x, $x, $_)`,
 		`reflect.Copy($x, $x)`,
 		`reflect.DeepEqual($x, $x)`,
-		`types.Identical($x, $y)`,
+		`types.Identical($x, $x)`,
 		`io.Copy($x, $x)`,
 		`copy($x, $x)`).
 		Report(`suspicious duplicated args in $$`)


### PR DESCRIPTION
False-positive:

```
$ ruleguard.bin -rules rules.go go/... 
/usr/local/go/src/go/internal/gcimporter/bimport.go:241:35: suspicious duplicated args in types.Identical(a.Type(), b.Type())
```