### PR TITLE
ruleguard,analyzer: implement rules debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ example.go:5:10: !(v1 != v2)
 
 It automatically inserts `Report("$$")` into the specified pattern.
 
+For named functions (rule groups) you can use `-debug-group <name>` flag to see explanations
+on why some rules rejected the match (e.g. which `Where()` condition failed).
+
 ## How does it work?
 
 `ruleguard` parses [gorules](docs/gorules.md) (e.g. `rules.go`) during the start to load the rule set.  

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -6,6 +6,7 @@ import (
 	"go/ast"
 	"go/token"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -23,11 +24,13 @@ var Analyzer = &analysis.Analyzer{
 var (
 	flagRules string
 	flagE     string
+	flagDebug string
 )
 
 func init() {
 	Analyzer.Flags.StringVar(&flagRules, "rules", "", "comma-separated list of gorule file paths")
 	Analyzer.Flags.StringVar(&flagE, "e", "", "execute a single rule from a given string")
+	Analyzer.Flags.StringVar(&flagDebug, "debug-group", "", "enable debug for the specified named rules group")
 }
 
 type parseRulesResult struct {
@@ -47,6 +50,10 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 	multiFile := parseResult.multiFile
 
 	ctx := &ruleguard.Context{
+		Debug: flagDebug,
+		DebugPrint: func(s string) {
+			fmt.Fprintln(os.Stderr, s)
+		},
 		Pkg:   pass.Pkg,
 		Types: pass.TypesInfo,
 		Sizes: pass.TypesSizes,

--- a/ruleguard/gorule.go
+++ b/ruleguard/gorule.go
@@ -13,7 +13,9 @@ type scopedGoRuleSet struct {
 }
 
 type goRule struct {
+	group      string
 	filename   string
+	line       int
 	severity   string
 	pat        *gogrep.Pattern
 	msg        string

--- a/ruleguard/parser.go
+++ b/ruleguard/parser.go
@@ -20,6 +20,7 @@ import (
 
 type rulesParser struct {
 	filename string
+	group    string
 	fset     *token.FileSet
 	res      *GoRuleSet
 	types    *types.Info
@@ -236,6 +237,8 @@ func (p *rulesParser) parseRuleGroup(f *ast.FuncDecl) error {
 	// TODO(quasilyte): do an actual matcher param type check?
 	matcher := params[0].Names[0].Name
 
+	p.group = f.Name.Name
+
 	p.itab.EnterScope()
 	defer p.itab.LeaveScope()
 
@@ -337,6 +340,8 @@ func (p *rulesParser) parseRule(matcher string, call *ast.CallExpr) error {
 	dst := p.res.universal
 	proto := goRule{
 		filename: p.filename,
+		line:     p.fset.Position(origCall.Pos()).Line,
+		group:    p.group,
 		filter: matchFilter{
 			sub: map[string]submatchFilter{},
 		},

--- a/ruleguard/ruleguard.go
+++ b/ruleguard/ruleguard.go
@@ -8,6 +8,9 @@ import (
 )
 
 type Context struct {
+	Debug      string
+	DebugPrint func(string)
+
 	Types  *types.Info
 	Sizes  types.Sizes
 	Fset   *token.FileSet
@@ -33,6 +36,12 @@ func RunRules(ctx *Context, f *ast.File, rules *GoRuleSet) error {
 type GoRuleInfo struct {
 	// Filename is a file that defined this rule.
 	Filename string
+
+	// Line is a line inside a file that defined this rule.
+	Line int
+
+	// Group is a function name that contained this rule.
+	Group string
 }
 
 type GoRuleSet struct {


### PR DESCRIPTION
When ruleguard is called with -debug-group=<string> arg,
it'll print rejected matches explanations to the stderr
for the specified rules group.

By default, this argument is an empty string that means "no debug".

Explanation includes:

	* Submatch nodes (with types)
	* Rejection reason (sometimes approx)
	* Rejected node location

Here is an example of how explanations can look like:

	example.go:4: rejected by rules.go:6 ($s type filter)
	  $s [10]int: a

	example2.go:9: rejected by rules.go:8 ($s2 is const)
	  $s1 string: v1
	  $s2 string: ""

	example2.go:7: rejected by rules.go:8 ($s1 is not const)
	  $s1 string: v1
	  $s2 string: v2

The debug output format is experimental and can change over time.
Any feedback is appreciated.

This change also adds Line:int and Group:string fields to the rules info.

	Line is a rules file line that declared this rule
	Group is a containing function name

The debug output format is experimental and can change over time.
Any feedback is appreciated.

Refs #98

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>