### PR TITLE
rules.go: add context.TODO

### DIFF
--- a/rules.go
+++ b/rules.go
@@ -412,3 +412,7 @@ func gosimpleS1003(m fluent.Matcher) {
 	m.Match(`strings.IndexAny($s1, $s2) != -1`).Suggest(`strings.ContainsAny($s1, $s2)`)
 	m.Match(`strings.IndexAny($s1, $s2) == -1`).Suggest(`!strings.ContainsAny($s1, $s2)`)
 }
+
+func contextTODO(m fluent.Matcher) {
+	m.Match(`context.TODO()`).Report(`consider to use well-defined context`)
+}


### PR DESCRIPTION
```
// TODO returns a non-nil, empty Context. Code should use context.TODO when
// it's unclear which Context to use or it is not yet available (because the
// surrounding function has not yet been extended to accept a Context
// parameter). TODO is recognized by static analysis tools that determine
// whether Contexts are propagated correctly in a program.
func TODO() Context {
	return todo
}
```
But last sentence was removed from the documentation in https://go-review.googlesource.com/c/go/+/130876/

Also issues https://github.com/golang/lint/pull/227 & https://github.com/golang/go/issues/16742
