### PR TITLE
ruleguard: fix interpolation of vars with common prefix

### DIFF
--- a/ruleguard/ruleguard_test.go
+++ b/ruleguard/ruleguard_test.go
@@ -1,0 +1,100 @@
+package ruleguard
+
+import (
+	"go/ast"
+	"go/token"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestRenderMessage(t *testing.T) {
+	tests := []struct {
+		msg  string
+		want string
+		vars []string
+	}{
+		{
+			`$x`,
+			`xvar`,
+			[]string{`x`},
+		},
+		{
+			`$x$x`,
+			`xvarxvar`,
+			[]string{`x`},
+		},
+		{
+			`$f $foo`,
+			`fvar foovar`,
+			[]string{`f`, `foo`},
+		},
+		{
+			`$foo $f`,
+			`foovar fvar`,
+			[]string{`f`, `foo`},
+		},
+		{
+			`$foo $f`,
+			`foovar fvar`,
+			[]string{`foo`, `f`},
+		},
+		{
+			`$foo $foo $f`,
+			`foovar foovar fvar`,
+			[]string{`foo`, `f`},
+		},
+		{
+			`$foo$f`,
+			`foovarfvar`,
+			[]string{`foo`, `f`},
+		},
+		{
+			`$foo($f) + $f.$foo`,
+			`foovar(fvar) + fvar.foovar`,
+			[]string{`foo`, `f`},
+		},
+
+		// Do we care about finding a proper variable border?
+		{
+			`$fooo`,
+			`foovaro`,
+			[]string{`foo`},
+		},
+
+		// Unknown $-expressions are not interpolated.
+		{
+			`$nonexisting`,
+			`$nonexisting`,
+			[]string{`x`},
+		},
+
+		// Double dollar interpolation.
+		{
+			`$$`,
+			`dd`,
+			[]string{`x`},
+		},
+		{
+			`$$[$x]`,
+			`dd[xvar]`,
+			[]string{`x`},
+		},
+	}
+
+	var rr rulesRunner
+	rr.ctx = &Context{
+		Fset: token.NewFileSet(),
+	}
+	for _, test := range tests {
+		nodes := make(map[string]ast.Node, len(test.vars))
+		for _, v := range test.vars {
+			nodes[v] = &ast.Ident{Name: v + "var"}
+		}
+
+		have := rr.renderMessage(test.msg, &ast.Ident{Name: "dd"}, nodes, false)
+		if diff := cmp.Diff(have, test.want); diff != "" {
+			t.Errorf("render %s %v:\n(+want -have)\n%s", test.msg, test.vars, diff)
+		}
+	}
+}


### PR DESCRIPTION
If pattern had variables where one of them is a prefix of another,
there was a chance of incorrect results.

This change makes renderMessage() sort keys and interpolate longer
var names first, so we avoid that risk.

Scratch slice is used to do the sorting, so no extra allocations
is added. As successfull matching is far less frequent than
a failed (or rejected) match, sorting should not affect the performance.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>