### PR TITLE
ruleguard: allow Var.Value.Int() and Var.Text as RHS

### DIFF
--- a/analyzer/testdata/src/gocritic/appendAssign.go
+++ b/analyzer/testdata/src/gocritic/appendAssign.go
@@ -1,0 +1,93 @@
+package gocritic
+
+func suspeciousAppends() {
+	var xs []int
+	var ys []int
+
+	xs = append(ys, 1) // want `\Qappend result not assigned to the same slice`
+	ys = append(xs, 1) // want `\Qappend result not assigned to the same slice`
+
+	{
+		xs2 := xs
+		xs = append(xs2, 1) // want `\Qappend result not assigned to the same slice`
+		xs2 = append(xs, 1) // want `\Qappend result not assigned to the same slice`
+	}
+}
+
+func normalAppends() {
+	var xs, ys []int
+
+	xs = append(xs, 1)
+	ys = append(ys, 1, 2)
+	xs = append(xs, ys[0], xs[0])
+}
+
+func permittedAppends() {
+	var xs, ys []int
+
+	// We're trying to detect `x = append(y, ...)` patterns
+	// where y is used instead of x by mistake, so lines below
+	// do not trigger a warning.
+
+	xs0 := append(xs, 1)
+	xs1 := append(xs, 1)
+	ys0 := append(ys, 1)
+
+	// Also permit to assign to "_".
+	_ = append(xs, xs0[0], xs1[1], ys0[0])
+
+	{
+		var m map[int][]int
+		xs := m[0]
+		m[0] = append(xs, 1)
+	}
+
+	// Sliced xs is still xs.
+	xs = append(xs[:0], 1)
+	xs = append(xs[1:], 2)
+
+	// OK to use slice literals.
+	xs = append([]int{}, 1)
+	xs = append([]int{1, 2}, 1)
+
+	// Also OK to use slices returned by a function calls.
+	xs = append(*new([]int), 1)
+	*(new([]int)) = append(*(new([]int)), 1)
+
+	// This prepends ys to the xs. Common idiom.
+	xs = append(ys, xs...)
+	xs = append(ys, xs[1:]...)
+
+	// Scratch array idiom.
+	var scratch [10]int
+	xs = append(scratch[:], 1)
+	xs = append(scratch[1:5], 2)
+
+	var withSlices struct {
+		a []int
+		b []int
+	}
+	withSlices.a = append(withSlices.a, 1)
+	withSlices.b = append(withSlices.b, 1)
+
+	var xsMap map[string][]int
+	xsMap["10"] = append(xsMap["10"], 1, 2)
+}
+
+func appendNotInAssignment() {
+	var xs, ys []int
+
+	// These are somewhat weird, but has nothing
+	// to do with diagnostic this checker wants to perform.
+
+	var v1 = append(xs, 1)
+	var (
+		v2 = append(xs, v1[0])
+		v3 = append(v2[1:], ys[0])
+	)
+	v4 := append(v3, xs[0])
+	{
+		v3 := append(v4, 1)
+		_ = v3
+	}
+}

--- a/analyzer/testdata/src/gocritic/f1.go
+++ b/analyzer/testdata/src/gocritic/f1.go
@@ -442,3 +442,22 @@ func rangeExprCopy() {
 		}
 	}
 }
+
+func badCond(x, y int) {
+	if x < -10 && x > 10 { // want `\Qthe condition is always false because -10 <= 10`
+	}
+
+	if x > 10 && x < -10 { // want `\Qthe condition is always false because 10 >= -10`
+	}
+
+	const ten = 10
+	if x > ten+1 && x < -10 { // want `\Qthe condition is always false because ten+1 >= -10`
+	}
+
+	// Don't know what value `y` have.
+	if x < y && x > 10 {
+	}
+
+	if x < -10 && y > 10 {
+	}
+}

--- a/analyzer/testdata/src/gocritic/rules.go
+++ b/analyzer/testdata/src/gocritic/rules.go
@@ -136,3 +136,22 @@ func _(m fluent.Matcher) {
 		At(m["x"]).
 		Suggest(`&$x`)
 }
+
+func badCond(m fluent.Matcher) {
+	m.Match(`$x < $a && $x > $b`).
+		Where(m["a"].Value.Int() <= m["b"].Value.Int()).
+		Report("the condition is always false because $a <= $b")
+
+	m.Match(`$x > $a && $x < $b`).
+		Where(m["a"].Value.Int() >= m["b"].Value.Int()).
+		Report("the condition is always false because $a >= $b")
+}
+
+func appendAssign(m fluent.Matcher) {
+	m.Match(`$x = append($y, $_, $*_)`).
+		Where(m["x"].Text != m["y"].Text &&
+			m["x"].Text != "_" &&
+			m["x"].Node.Is(`Ident`) &&
+			m["y"].Node.Is(`Ident`)).
+		Report("append result not assigned to the same slice")
+}

--- a/ruleguard/gorule.go
+++ b/ruleguard/gorule.go
@@ -47,8 +47,9 @@ type nodeFilter struct {
 }
 
 type nodeFilterParams struct {
-	ctx *Context
-	n   ast.Expr
+	ctx    *Context
+	n      ast.Expr
+	values map[string]ast.Node
 
 	nodeText func(n ast.Node) []byte
 }

--- a/ruleguard/runner.go
+++ b/ruleguard/runner.go
@@ -164,6 +164,7 @@ func (rr *rulesRunner) handleMatch(rule goRule, m gogrep.MatchData) bool {
 		}
 	}
 
+	rr.nodeFilterParams.values = m.Values
 	for name, node := range m.Values {
 		var expr ast.Expr
 		switch node := node.(type) {

--- a/ruleguard/utils.go
+++ b/ruleguard/utils.go
@@ -2,6 +2,7 @@ package ruleguard
 
 import (
 	"go/ast"
+	"go/constant"
 	"go/parser"
 	"go/printer"
 	"go/token"
@@ -104,6 +105,17 @@ func typeFromNode(e ast.Expr) types.Type {
 	}
 
 	return nil
+}
+
+func intValueOf(info *types.Info, expr ast.Expr) constant.Value {
+	tv := info.Types[expr]
+	if tv.Value == nil {
+		return nil
+	}
+	if tv.Value.Kind() != constant.Int {
+		return nil
+	}
+	return tv.Value
 }
 
 // isPure reports whether expr is a softly safe expression and contains


### PR DESCRIPTION
This is not a general solution to the problem, but it works.

Refs #125
Fixes #2
Fixes #3

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>