### PR TITLE
Handle type in a vendored directory

### DIFF
--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -19,6 +19,7 @@ func TestAnalyzer(t *testing.T) {
 		"revive",
 		"golint",
 		"regression",
+		"testvendored",
 	}
 
 	for _, test := range tests {

--- a/analyzer/testdata/src/testvendored/file.go
+++ b/analyzer/testdata/src/testvendored/file.go
@@ -1,0 +1,21 @@
+package vendored
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.invalid/globex/logging"
+)
+
+func example() {
+	err := fmt.Errorf("Failed to configure system. Error: %v", errors.New("test")) // want `nothing special, just testing the Errorf rule`
+
+	logger := logging.GetLogger()
+	logger.Errorf("Failed to configure system. Error: %v", err)         // want `Errors must be logged as a structured field`
+	logger.Errorf("Failed to configure system. Error: %v", err.Error()) // want `Errors must be logged as a structured field`
+
+	name := "abc"
+	logger.Errorf("Configure system %s", name)
+	logger.Errorf("Failed to configure system %s. Error: %v", strings.ToLower(name), err.Error()) // want `Errors must be logged as a structured field`
+}

--- a/analyzer/testdata/src/testvendored/rules.go
+++ b/analyzer/testdata/src/testvendored/rules.go
@@ -1,0 +1,37 @@
+// +build ignore
+
+package gorules
+
+import "github.com/quasilyte/go-ruleguard/dsl/fluent"
+
+func _(m fluent.Matcher) {
+	// Test a vendored dependency can be imported successfully and used in a Where statement.
+	// Otherwise, the rules semantics are not important.
+
+	// Import a dependency which happens to be vendored, i.e. it has been downloaded under the "vendor" directory
+	// instead of being pulled from the Internet.
+	// Using the .invalid name (RFC 2606) to ensure the unit test is not accidentally downloading files.
+	m.Import(`github.invalid/globex/logging`)
+
+	// This rule should match a function named 'Errorf' that has an argument that implements the 'error' interface.
+	// In addition, we only want to match the Errorf() function implemented by the logging.Logger struct.
+	// We don't want to match fmt.Errorf().
+	// We also simulate the fact github.invalid/globex/logging is vendored, i.e. it is in the 'vendor' directory.
+	// This means while analyzing the code, the AST type is '*testvendored/github.invalid/globex/logging/Logger',
+	// and yet m["x"].Type.Is("*logging.Logger") should return true.
+	m.Match(
+		`$x.Errorf($fmt, $*_, $y, $*_)`,
+		`$x.Errorf($fmt, $*_, $y.Error(), $*_)`,
+	).
+		Where(m["x"].Type.Is("*logging.Logger") && m["y"].Type.Implements("error")).
+		Report(`Errors must be logged as a structured field`)
+
+	// A test rule that matches any function named 'Errorf' such as logging.Logger.Errorf() or fmt.Errorf()
+	m.Match(
+		`$x.Errorf($fmt, $*_, $y, $*_)`,
+		`$x.Errorf($fmt, $*_, $y.Error(), $*_)`,
+	).
+		Where(m["y"].Type.Implements("error")).
+		Report(`nothing special, just testing the Errorf rule`)
+
+}

--- a/analyzer/testdata/src/testvendored/vendor/github.invalid/globex/logging/logger.go
+++ b/analyzer/testdata/src/testvendored/vendor/github.invalid/globex/logging/logger.go
@@ -1,0 +1,18 @@
+package logging
+
+// Logger implements a dummy logger to test vendored dependencies.
+type Logger struct {
+}
+
+// Infof logs a message at error level.
+func (l *Logger) Infof(fmt string, args ...interface{}) {
+}
+
+// Errorf logs a message at error level.
+func (l *Logger) Errorf(fmt string, args ...interface{}) {
+}
+
+// GetLogger returns a Logger instance.
+func GetLogger() *Logger {
+	return &Logger{}
+}

--- a/ruleguard/typematch/typematch.go
+++ b/ruleguard/typematch/typematch.go
@@ -304,6 +304,7 @@ func parseExpr(ctx *Context, e ast.Expr) *pattern {
 	return nil
 }
 
+// MatchIdentical returns true if the go typ matches pattern p.
 func (p *Pattern) MatchIdentical(typ types.Type) bool {
 	p.reset()
 	return p.matchIdentical(p.root, typ)
@@ -455,7 +456,9 @@ func (p *Pattern) matchIdentical(sub *pattern, typ types.Type) bool {
 		}
 		pkgPath := sub.value.([2]string)[0]
 		typeName := sub.value.([2]string)[1]
-		return obj.Pkg().Path() == pkgPath && typeName == obj.Name()
+		// obj.Pkg().Path() may be in a vendor directory.
+		path := strings.SplitAfter(obj.Pkg().Path(), "/vendor/")
+		return path[len(path)-1] == pkgPath && typeName == obj.Name()
 
 	case opFunc:
 		typ, ok := typ.(*types.Signature)


### PR DESCRIPTION
Fix for #135.
I haven't looked into what are all the possible ways that a package can be imported, and how the type path would look like.