### PR TITLE
Add unit tests for vendored dependencies

### DIFF
--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -19,6 +19,7 @@ func TestAnalyzer(t *testing.T) {
 		"revive",
 		"golint",
 		"regression",
+		"testvendored",
 	}
 
 	for _, test := range tests {

--- a/analyzer/testdata/src/testvendored/file.go
+++ b/analyzer/testdata/src/testvendored/file.go
@@ -1,0 +1,21 @@
+package vendored
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.invalid/globex/logging"
+)
+
+func example() {
+	err := fmt.Errorf("Failed to configure system. Error: %v", errors.New("test")) // want `nothing special, just testing the Errorf rule`
+
+	logger := logging.GetLogger()
+	logger.Errorf("Failed to configure system. Error: %v", err)         // want `Errors must be logged as a structured field`
+	logger.Errorf("Failed to configure system. Error: %v", err.Error()) // want `Errors must be logged as a structured field`
+
+	name := "abc"
+	logger.Errorf("Configure system %s", name)
+	logger.Errorf("Failed to configure system %s. Error: %v", strings.ToLower(name), err.Error()) // want `Errors must be logged as a structured field`
+}

--- a/analyzer/testdata/src/testvendored/rules.go
+++ b/analyzer/testdata/src/testvendored/rules.go
@@ -1,0 +1,37 @@
+// +build ignore
+
+package gorules
+
+import "github.com/quasilyte/go-ruleguard/dsl/fluent"
+
+func _(m fluent.Matcher) {
+	// Test a vendored dependency can be imported successfully and used in a Where statement.
+	// Otherwise, the rules semantics are not important.
+
+	// Import a dependency which happens to be vendored, i.e. it has been downloaded under the "vendor" directory
+	// instead of being pulled from the Internet.
+	// Using the .invalid name (RFC 2606) to ensure the unit test is not accidentally downloading files.
+	m.Import(`github.invalid/globex/logging`)
+
+	// This rule should match a function named 'Errorf' that has an argument that implements the 'error' interface.
+	// In addition, we only want to match the Errorf() function implemented by the logging.Logger struct.
+	// We don't want to match fmt.Errorf().
+	// We also simulate the fact github.invalid/globex/logging is vendored, i.e. it is in the 'vendor' directory.
+	// This means while analyzing the code, the AST type is '*testvendored/github.invalid/globex/logging/Logger',
+	// and yet m["x"].Type.Is("*logging.Logger") should return true.
+	m.Match(
+		`$x.Errorf($fmt, $*_, $y, $*_)`,
+		`$x.Errorf($fmt, $*_, $y.Error(), $*_)`,
+	).
+		Where(m["x"].Type.Is("*logging.Logger") && m["y"].Type.Implements("error")).
+		Report(`Errors must be logged as a structured field`)
+
+	// A test rule that matches any function named 'Errorf' such as logging.Logger.Errorf() or fmt.Errorf()
+	m.Match(
+		`$x.Errorf($fmt, $*_, $y, $*_)`,
+		`$x.Errorf($fmt, $*_, $y.Error(), $*_)`,
+	).
+		Where(m["y"].Type.Implements("error")).
+		Report(`nothing special, just testing the Errorf rule`)
+
+}

--- a/analyzer/testdata/src/testvendored/vendor/github.invalid/globex/logging/logger.go
+++ b/analyzer/testdata/src/testvendored/vendor/github.invalid/globex/logging/logger.go
@@ -1,0 +1,18 @@
+package logging
+
+// Logger implements a dummy logger to test vendored dependencies.
+type Logger struct {
+}
+
+// Infof logs a message at error level.
+func (l *Logger) Infof(fmt string, args ...interface{}) {
+}
+
+// Errorf logs a message at error level.
+func (l *Logger) Errorf(fmt string, args ...interface{}) {
+}
+
+// GetLogger returns a Logger instance.
+func GetLogger() *Logger {
+	return &Logger{}
+}


### PR DESCRIPTION
This PR has the unit tests for #136. It is expected to fail. The purpose is to show code is needed to handle vendored dependencies. It is not meant to be merged.