### PR TITLE
ruleguard: filter parsing improvements

### DIFF
--- a/analyzer/testdata/src/regression/issue115.go
+++ b/analyzer/testdata/src/regression/issue115.go
@@ -1,0 +1,13 @@
+package regression
+
+func testIssue115() {
+	intFunc := func() int { return 19 }
+	stringFunc := func() string { return "19" }
+
+	println(13)
+	println(43 + 5)
+
+	println("foo")        // want `\Q"foo" is not a constexpr int`
+	println(intFunc())    // want `\QintFunc() is not a constexpr int`
+	println(stringFunc()) // want `\QstringFunc() is not a constexpr int`
+}

--- a/analyzer/testdata/src/regression/rules.go
+++ b/analyzer/testdata/src/regression/rules.go
@@ -19,3 +19,9 @@ func issue72(m fluent.Matcher) {
 		`fmt.Sprintf("%s<%s>", $name, $email)`).
 		Report("use net/mail Address.String() instead of fmt.Sprintf()")
 }
+
+func issue115(m fluent.Matcher) {
+	m.Match(`println($x)`).
+		Where(!(m["x"].Const && m["x"].Type.Is("int"))).
+		Report("$x is not a constexpr int")
+}

--- a/ruleguard/debug_test.go
+++ b/ruleguard/debug_test.go
@@ -40,12 +40,11 @@ func TestDebug(t *testing.T) {
 			},
 		},
 
-		// TODO(quasilyte): don't lose "!" in the debug output.
 		`m.Match("$x + $_").Where(!m["x"].Type.Is("int"))`: {
 			`sink = "a" + "b"`: nil,
 
 			`sink = int(10) + 20`: {
-				`input.go:4: [rules.go:5] rejected by m["x"].Type.Is("int")`,
+				`input.go:4: [rules.go:5] rejected by !m["x"].Type.Is("int")`,
 				`  $x int: int(10)`,
 			},
 		},
@@ -89,6 +88,56 @@ func TestDebug(t *testing.T) {
 			`_ = f((10))`: {
 				`input.go:4: [rules.go:5] rejected by m["x"].Node.Is("ParenExpr")`,
 				`  $x interface{}: f((10))`,
+			},
+		},
+
+		// When debugging OR, the last alternative will be reported as the failure reason,
+		// although it should be obvious that all operands are falsy.
+		// We don't return the entire OR expression as a reason to avoid the output cluttering.
+		`m.Match("_ = $x").Where(m["x"].Type.Is("int") || m["x"].Type.Is("string"))`: {
+			`_ = ""`: nil,
+			`_ = 10`: nil,
+
+			`_ = []int{}`: {
+				`input.go:4: [rules.go:5] rejected by m["x"].Type.Is("string")`,
+				`  $x []int: []int{}`,
+			},
+
+			`_ = int32(0)`: {
+				`input.go:4: [rules.go:5] rejected by m["x"].Type.Is("string")`,
+				`  $x int32: int32(0)`,
+			},
+		},
+
+		// Using 3 operands for || and different ()-groupings.
+		`m.Match("_ = $x").Where(m["x"].Type.Is("int") || m["x"].Type.Is("string") || m["x"].Text == "f()")`: {
+			`_ = ""`:  nil,
+			`_ = 10`:  nil,
+			`_ = f()`: nil,
+
+			`_ = []string{"x"}`: {
+				`input.go:4: [rules.go:5] rejected by m["x"].Text == "f()"`,
+				`  $x []string: []string{"x"}`,
+			},
+		},
+		`m.Match("_ = $x").Where(m["x"].Type.Is("int") || (m["x"].Type.Is("string") || m["x"].Text == "f()"))`: {
+			`_ = ""`:  nil,
+			`_ = 10`:  nil,
+			`_ = f()`: nil,
+
+			`_ = []string{"x"}`: {
+				`input.go:4: [rules.go:5] rejected by m["x"].Text == "f()"`,
+				`  $x []string: []string{"x"}`,
+			},
+		},
+		`m.Match("_ = $x").Where((m["x"].Type.Is("int") || m["x"].Type.Is("string")) || m["x"].Text == "f()")`: {
+			`_ = ""`:  nil,
+			`_ = 10`:  nil,
+			`_ = f()`: nil,
+
+			`_ = []string{"x"}`: {
+				`input.go:4: [rules.go:5] rejected by m["x"].Text == "f()"`,
+				`  $x []string: []string{"x"}`,
 			},
 		},
 	}

--- a/ruleguard/filters.go
+++ b/ruleguard/filters.go
@@ -1,0 +1,246 @@
+package ruleguard
+
+import (
+	"go/ast"
+	"go/constant"
+	"go/token"
+	"go/types"
+	"path/filepath"
+	"regexp"
+
+	"github.com/quasilyte/go-ruleguard/ruleguard/typematch"
+)
+
+const filterSuccess = matchFilterResult("")
+
+func filterFailure(reason string) matchFilterResult {
+	return matchFilterResult(reason)
+}
+
+func makeNotFilter(src string, x matchFilter) filterFunc {
+	return func(params *filterParams) matchFilterResult {
+		if x.fn(params).Matched() {
+			return matchFilterResult(src)
+		}
+		return ""
+	}
+}
+
+func makeAndFilter(lhs, rhs matchFilter) filterFunc {
+	return func(params *filterParams) matchFilterResult {
+		if lhsResult := lhs.fn(params); !lhsResult.Matched() {
+			return lhsResult
+		}
+		return rhs.fn(params)
+	}
+}
+
+func makeOrFilter(lhs, rhs matchFilter) filterFunc {
+	return func(params *filterParams) matchFilterResult {
+		if lhsResult := lhs.fn(params); lhsResult.Matched() {
+			return filterSuccess
+		}
+		return rhs.fn(params)
+	}
+}
+
+func makeFileImportsFilter(src, pkgPath string) filterFunc {
+	return func(params *filterParams) matchFilterResult {
+		_, imported := params.imports[pkgPath]
+		if imported {
+			return filterSuccess
+		}
+		return filterFailure(src)
+	}
+}
+
+func makeFilePkgPathMatchesFilter(src string, re *regexp.Regexp) filterFunc {
+	return func(params *filterParams) matchFilterResult {
+		pkgPath := params.ctx.Pkg.Path()
+		if re.MatchString(pkgPath) {
+			return filterSuccess
+		}
+		return filterFailure(src)
+	}
+}
+
+func makeFileNameMatchesFilter(src string, re *regexp.Regexp) filterFunc {
+	return func(params *filterParams) matchFilterResult {
+		if re.MatchString(filepath.Base(params.filename)) {
+			return filterSuccess
+		}
+		return filterFailure(src)
+	}
+}
+
+func makePureFilter(src, varname string) filterFunc {
+	return func(params *filterParams) matchFilterResult {
+		n := params.subExpr(varname)
+		if isPure(params.ctx.Types, n) {
+			return filterSuccess
+		}
+		return filterFailure(src)
+	}
+}
+
+func makeConstFilter(src, varname string) filterFunc {
+	return func(params *filterParams) matchFilterResult {
+		n := params.subExpr(varname)
+		if isConstant(params.ctx.Types, n) {
+			return filterSuccess
+		}
+		return filterFailure(src)
+	}
+}
+
+func makeAddressableFilter(src, varname string) filterFunc {
+	return func(params *filterParams) matchFilterResult {
+		n := params.subExpr(varname)
+		if isAddressable(params.ctx.Types, n) {
+			return filterSuccess
+		}
+		return filterFailure(src)
+	}
+}
+
+func makeTypeImplementsFilter(src, varname string, iface *types.Interface) filterFunc {
+	return func(params *filterParams) matchFilterResult {
+		typ := params.typeofNode(params.subExpr(varname))
+		if types.Implements(typ, iface) {
+			return filterSuccess
+		}
+		return filterFailure(src)
+	}
+}
+
+func makeTypeIsFilter(src, varname string, underlying bool, pat *typematch.Pattern) filterFunc {
+	if underlying {
+		return func(params *filterParams) matchFilterResult {
+			typ := params.typeofNode(params.subExpr(varname)).Underlying()
+			if pat.MatchIdentical(typ) {
+				return filterSuccess
+			}
+			return filterFailure(src)
+		}
+	}
+	return func(params *filterParams) matchFilterResult {
+		typ := params.typeofNode(params.subExpr(varname))
+		if pat.MatchIdentical(typ) {
+			return filterSuccess
+		}
+		return filterFailure(src)
+	}
+}
+
+func makeTypeConvertibleToFilter(src, varname string, dstType types.Type) filterFunc {
+	return func(params *filterParams) matchFilterResult {
+		typ := params.typeofNode(params.subExpr(varname))
+		if types.ConvertibleTo(typ, dstType) {
+			return filterSuccess
+		}
+		return filterFailure(src)
+	}
+}
+
+func makeTypeAssignableToFilter(src, varname string, dstType types.Type) filterFunc {
+	return func(params *filterParams) matchFilterResult {
+		typ := params.typeofNode(params.subExpr(varname))
+		if types.AssignableTo(typ, dstType) {
+			return filterSuccess
+		}
+		return filterFailure(src)
+	}
+}
+
+func makeTypeSizeConstFilter(src, varname string, op token.Token, rhsValue constant.Value) filterFunc {
+	return func(params *filterParams) matchFilterResult {
+		typ := params.typeofNode(params.subExpr(varname))
+		lhsValue := constant.MakeInt64(params.ctx.Sizes.Sizeof(typ))
+		if constant.Compare(lhsValue, op, rhsValue) {
+			return filterSuccess
+		}
+		return filterFailure(src)
+	}
+}
+
+func makeValueIntConstFilter(src, varname string, op token.Token, rhsValue constant.Value) filterFunc {
+	return func(params *filterParams) matchFilterResult {
+		lhsValue := intValueOf(params.ctx.Types, params.subExpr(varname))
+		if lhsValue == nil {
+			return filterFailure(src) // The value is unknown
+		}
+		if constant.Compare(lhsValue, op, rhsValue) {
+			return filterSuccess
+		}
+		return filterFailure(src)
+	}
+}
+
+func makeValueIntFilter(src, varname string, op token.Token, rhsVarname string) filterFunc {
+	return func(params *filterParams) matchFilterResult {
+		lhsValue := intValueOf(params.ctx.Types, params.subExpr(varname))
+		if lhsValue == nil {
+			return filterFailure(src)
+		}
+		rhsValue := intValueOf(params.ctx.Types, params.subExpr(rhsVarname))
+		if rhsValue == nil {
+			return filterFailure(src)
+		}
+		if constant.Compare(lhsValue, op, rhsValue) {
+			return filterSuccess
+		}
+		return filterFailure(src)
+	}
+}
+
+func makeTextConstFilter(src, varname string, op token.Token, rhsValue constant.Value) filterFunc {
+	return func(params *filterParams) matchFilterResult {
+		s := params.nodeText(params.subExpr(varname))
+		lhsValue := constant.MakeString(string(s))
+		if constant.Compare(lhsValue, op, rhsValue) {
+			return filterSuccess
+		}
+		return filterFailure(src)
+	}
+}
+
+func makeTextFilter(src, varname string, op token.Token, rhsVarname string) filterFunc {
+	return func(params *filterParams) matchFilterResult {
+		s1 := params.nodeText(params.subExpr(varname))
+		lhsValue := constant.MakeString(string(s1))
+		s2 := params.nodeText(params.values[rhsVarname])
+		rhsValue := constant.MakeString(string(s2))
+		if constant.Compare(lhsValue, op, rhsValue) {
+			return filterSuccess
+		}
+		return filterFailure(src)
+	}
+}
+
+func makeTextMatchesFilter(src, varname string, re *regexp.Regexp) filterFunc {
+	return func(params *filterParams) matchFilterResult {
+		if re.Match(params.nodeText(params.subExpr(varname))) {
+			return filterSuccess
+		}
+		return filterFailure(src)
+	}
+}
+
+func makeNodeIsFilter(src, varname string, cat nodeCategory) filterFunc {
+	return func(params *filterParams) matchFilterResult {
+		n := params.subExpr(varname)
+		var matched bool
+		switch cat {
+		case nodeExpr:
+			_, matched = n.(ast.Expr)
+		case nodeStmt:
+			_, matched = n.(ast.Stmt)
+		default:
+			matched = (cat == categorizeNode(n))
+		}
+		if matched {
+			return filterSuccess
+		}
+		return filterFailure(src)
+	}
+}

--- a/ruleguard/gorule.go
+++ b/ruleguard/gorule.go
@@ -25,40 +25,41 @@ type goRule struct {
 	filter     matchFilter
 }
 
+type matchFilterResult string
+
+func (s matchFilterResult) Matched() bool { return s == "" }
+
+func (s matchFilterResult) RejectReason() string { return string(s) }
+
+type filterFunc func(*filterParams) matchFilterResult
+
 type matchFilter struct {
-	fileFilters []fileFilter
-	subFilters  map[string][]nodeFilter
+	src string
+	fn  func(*filterParams) matchFilterResult
 }
 
-type fileFilter struct {
-	src  string
-	pred func(*fileFilterParams) bool
-}
-
-type fileFilterParams struct {
+type filterParams struct {
 	ctx      *Context
 	filename string
 	imports  map[string]struct{}
-}
 
-type nodeFilter struct {
-	src  string
-	pred func(*nodeFilterParams) bool
-}
-
-type nodeFilterParams struct {
-	ctx    *Context
-	n      ast.Expr
 	values map[string]ast.Node
 
 	nodeText func(n ast.Node) []byte
 }
 
-func (params *nodeFilterParams) nodeType() types.Type {
-	return params.typeofNode(params.n)
+func (params *filterParams) subExpr(name string) ast.Expr {
+	switch n := params.values[name].(type) {
+	case ast.Expr:
+		return n
+	case *ast.ExprStmt:
+		return n.X
+	default:
+		return nil
+	}
 }
 
-func (params *nodeFilterParams) typeofNode(n ast.Node) types.Type {
+func (params *filterParams) typeofNode(n ast.Node) types.Type {
 	if e, ok := n.(ast.Expr); ok {
 		if typ := params.ctx.Types.TypeOf(e); typ != nil {
 			return typ

--- a/ruleguard/runner.go
+++ b/ruleguard/runner.go
@@ -24,23 +24,19 @@ type rulesRunner struct {
 	// A slice that is used to do a nodes keys sorting in renderMessage().
 	sortScratch []string
 
-	fileFilterParams fileFilterParams
-	nodeFilterParams nodeFilterParams
+	filterParams filterParams
 }
 
 func newRulesRunner(ctx *Context, rules *GoRuleSet) *rulesRunner {
 	rr := &rulesRunner{
 		ctx:   ctx,
 		rules: rules,
-		fileFilterParams: fileFilterParams{
-			ctx: ctx,
-		},
-		nodeFilterParams: nodeFilterParams{
+		filterParams: filterParams{
 			ctx: ctx,
 		},
 		sortScratch: make([]string, 0, 8),
 	}
-	rr.nodeFilterParams.nodeText = rr.nodeText
+	rr.filterParams.nodeText = rr.nodeText
 	return rr
 }
 
@@ -80,7 +76,7 @@ func (rr *rulesRunner) run(f *ast.File) error {
 	// TODO(quasilyte): run local rules as well.
 
 	rr.filename = rr.ctx.Fset.Position(f.Pos()).Filename
-	rr.fileFilterParams.filename = rr.filename
+	rr.filterParams.filename = rr.filename
 	rr.collectImports(f)
 
 	for _, rule := range rr.rules.universal.uncategorized {
@@ -109,10 +105,6 @@ func (rr *rulesRunner) run(f *ast.File) error {
 }
 
 func (rr *rulesRunner) reject(rule goRule, reason string, m gogrep.MatchData) {
-	// Note: we accept reason and sub args instead of formatted or
-	// concatenated string so it's cheaper for us to call this
-	// function is debugging is not enabled.
-
 	if rule.group != rr.ctx.Debug {
 		return // This rule is not being debugged
 	}
@@ -157,31 +149,12 @@ func (rr *rulesRunner) reject(rule goRule, reason string, m gogrep.MatchData) {
 }
 
 func (rr *rulesRunner) handleMatch(rule goRule, m gogrep.MatchData) bool {
-	for _, f := range rule.filter.fileFilters {
-		if !f.pred(&rr.fileFilterParams) {
-			rr.reject(rule, f.src, m)
+	if rule.filter.fn != nil {
+		rr.filterParams.values = m.Values
+		filterResult := rule.filter.fn(&rr.filterParams)
+		if !filterResult.Matched() {
+			rr.reject(rule, filterResult.RejectReason(), m)
 			return false
-		}
-	}
-
-	rr.nodeFilterParams.values = m.Values
-	for name, node := range m.Values {
-		var expr ast.Expr
-		switch node := node.(type) {
-		case ast.Expr:
-			expr = node
-		case *ast.ExprStmt:
-			expr = node.X
-		default:
-			continue
-		}
-
-		rr.nodeFilterParams.n = expr
-		for _, f := range rule.filter.subFilters[name] {
-			if !f.pred(&rr.nodeFilterParams) {
-				rr.reject(rule, f.src, m)
-				return false
-			}
 		}
 	}
 
@@ -210,13 +183,13 @@ func (rr *rulesRunner) handleMatch(rule goRule, m gogrep.MatchData) bool {
 }
 
 func (rr *rulesRunner) collectImports(f *ast.File) {
-	rr.fileFilterParams.imports = make(map[string]struct{}, len(f.Imports))
+	rr.filterParams.imports = make(map[string]struct{}, len(f.Imports))
 	for _, spec := range f.Imports {
 		s, err := strconv.Unquote(spec.Path.Value)
 		if err != nil {
 			continue
 		}
-		rr.fileFilterParams.imports[s] = struct{}{}
+		rr.filterParams.imports[s] = struct{}{}
 	}
 }
 


### PR DESCRIPTION
Refactored Where() filter parsing code.

Implemented || operator while at it.

Fixes #115 !(A && B) conditions now work properly
Fixes #26  A || B    conditions are now implemented