### PR TITLE
ruleguard: set GoRuleInfo fields before passing it to Report()

### DIFF
--- a/ruleguard/runner.go
+++ b/ruleguard/runner.go
@@ -176,7 +176,9 @@ func (rr *rulesRunner) handleMatch(rule goRule, m gogrep.MatchData) bool {
 		}
 	}
 	info := GoRuleInfo{
+		Group:    rule.group,
 		Filename: rule.filename,
+		Line:     rule.line,
 	}
 	rr.ctx.Report(info, node, message, suggestion)
 	return true


### PR DESCRIPTION
The GoRuleInfo.Line and GoRuleInfo.Group fields were not initialized correctly.