### PR TITLE
all: forbid unnamed rule groups `func _()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,14 @@ package gorules
 
 import "github.com/quasilyte/go-ruleguard/dsl/fluent"
 
-func _(m fluent.Matcher) {
+func dupSubExpr(m fluent.Matcher) {
 	m.Match(`$x || $x`,
 		`$x && $x`).
 		Where(m["x"].Pure).
 		Report(`suspicious identical LHS and RHS`)
+}
 
+func boolExprSimplify(m fluent.Matcher) {
 	m.Match(`!($x != $y)`).Suggest(`$x == $y`)
 	m.Match(`!($x == $y)`).Suggest(`$x != $y`)
 }
@@ -109,8 +111,10 @@ example.go:5:10: !(v1 != v2)
 
 It automatically inserts `Report("$$")` into the specified pattern.
 
-For named functions (rule groups) you can use `-debug-group <name>` flag to see explanations
+You can use `-debug-group <name>` flag to see explanations
 on why some rules rejected the match (e.g. which `Where()` condition failed).
+
+The `-e` generated rule will have `e` name, so it can be debugged as well.
 
 ## How does it work?
 

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -30,7 +30,7 @@ var (
 func init() {
 	Analyzer.Flags.StringVar(&flagRules, "rules", "", "comma-separated list of gorule file paths")
 	Analyzer.Flags.StringVar(&flagE, "e", "", "execute a single rule from a given string")
-	Analyzer.Flags.StringVar(&flagDebug, "debug-group", "", "enable debug for the specified named rules group")
+	Analyzer.Flags.StringVar(&flagDebug, "debug-group", "", "enable debug for the specified function")
 }
 
 type parseRulesResult struct {
@@ -119,7 +119,7 @@ func readRules() (*parseRulesResult, error) {
 		ruleText := fmt.Sprintf(`
 			package gorules
 			import "github.com/quasilyte/go-ruleguard/dsl/fluent"
-			func _(m fluent.Matcher) {
+			func e(m fluent.Matcher) {
 				%s.Report("$$")
 			}`,
 			flagE)

--- a/analyzer/testdata/src/extra/rules.go
+++ b/analyzer/testdata/src/extra/rules.go
@@ -4,7 +4,7 @@ package gorules
 
 import "github.com/quasilyte/go-ruleguard/dsl/fluent"
 
-func _(m fluent.Matcher) {
+func testRules(m fluent.Matcher) {
 	// We don't want to suggest int64(x) if x is already int64,
 	// this is why 2 rules are needed.
 	// Maybe there will be a way to group these 2 together in

--- a/analyzer/testdata/src/filtertest/rules.go
+++ b/analyzer/testdata/src/filtertest/rules.go
@@ -4,7 +4,7 @@ package gorules
 
 import "github.com/quasilyte/go-ruleguard/dsl/fluent"
 
-func _(m fluent.Matcher) {
+func testRules(m fluent.Matcher) {
 	m.Import(`github.com/quasilyte/go-ruleguard/analyzer/testdata/src/filtertest/foolib`)
 
 	m.Match(`typeTest($x, "contains time.Time")`).

--- a/analyzer/testdata/src/gocritic/rules.go
+++ b/analyzer/testdata/src/gocritic/rules.go
@@ -4,7 +4,7 @@ package gorules
 
 import "github.com/quasilyte/go-ruleguard/dsl/fluent"
 
-func _(m fluent.Matcher) {
+func testRules(m fluent.Matcher) {
 	m.Match(`$x = $x`).Report(`suspicious self-assignment in $$`)
 
 	m.Match(`$tmp := $x; $x = $y; $y = $tmp`).

--- a/analyzer/testdata/src/golint/rules.go
+++ b/analyzer/testdata/src/golint/rules.go
@@ -4,7 +4,7 @@ package gorules
 
 import "github.com/quasilyte/go-ruleguard/dsl/fluent"
 
-func _(m fluent.Matcher) {
+func testRules(m fluent.Matcher) {
 	m.Match(`errors.New(fmt.Sprintf($*_))`).
 		Report(`should replace error.New(fmt.Sprintf(...)) with fmt.Errorf(...)`)
 	m.Match(`t.Error(fmt.Sprintf($*_))`).

--- a/analyzer/testdata/src/namedtype/nested/rules.go
+++ b/analyzer/testdata/src/namedtype/nested/rules.go
@@ -4,7 +4,7 @@ package gorules
 
 import "github.com/quasilyte/go-ruleguard/dsl/fluent"
 
-func _(m fluent.Matcher) {
+func testRules(m fluent.Matcher) {
 	m.Import(`namedtype/x/nested`)
 	m.Import(`extra`)
 

--- a/analyzer/testdata/src/namedtype/rules.go
+++ b/analyzer/testdata/src/namedtype/rules.go
@@ -4,7 +4,7 @@ package gorules
 
 import "github.com/quasilyte/go-ruleguard/dsl/fluent"
 
-func _(m fluent.Matcher) {
+func testRules(m fluent.Matcher) {
 	m.Import(`namedtype/x/nested`)
 
 	m.Match(`sink = &$t`).

--- a/analyzer/testdata/src/revive/rules.go
+++ b/analyzer/testdata/src/revive/rules.go
@@ -4,7 +4,7 @@ package gorules
 
 import "github.com/quasilyte/go-ruleguard/dsl/fluent"
 
-func _(m fluent.Matcher) {
+func testRules(m fluent.Matcher) {
 	m.Match(`runtime.GC()`).Report(`explicit call to GC`)
 
 	m.Match(`$x = atomic.AddInt32(&$x, $_)`,

--- a/analyzer/testdata/src/suggest/rules.go
+++ b/analyzer/testdata/src/suggest/rules.go
@@ -4,6 +4,6 @@ package gorules
 
 import "github.com/quasilyte/go-ruleguard/dsl/fluent"
 
-func _(m fluent.Matcher) {
+func testRules(m fluent.Matcher) {
 	m.Match(`($a) || ($b)`).Suggest(`$a || $b`)
 }

--- a/analyzer/testdata/src/testvendored/rules.go
+++ b/analyzer/testdata/src/testvendored/rules.go
@@ -4,7 +4,7 @@ package gorules
 
 import "github.com/quasilyte/go-ruleguard/dsl/fluent"
 
-func _(m fluent.Matcher) {
+func testRules(m fluent.Matcher) {
 	// Test a vendored dependency can be imported successfully and used in a Where statement.
 	// Otherwise, the rules semantics are not important.
 

--- a/docs/gorules.md
+++ b/docs/gorules.md
@@ -39,15 +39,13 @@ package gorules
 
 import "github.com/quasilyte/go-ruleguard/dsl/fluent"
 
-func _(m fluent.Matcher) {
+func regexpMust(m fluent.Matcher) {
 	m.Match(`regexp.Compile($pat)`,
 		`regexp.CompilePOSIX($pat)`).
 		Where(m["pat"].Const).
 		Report(`can use MustCompile for const patterns`)
 }
 ```
-
-A rule group that has `_` function name is called **anonymous**. You can have as much anonymous groups as you like.
 
 A `Report` argument string can use `$<varname>` notation to interpolate the named pattern submatches into the report message.
 There is a special case of `$$` which can be used to inject the entire pattern match into the message.
@@ -61,7 +59,7 @@ As everything else, statements are `Matcher` methods. [`Import()`](https://godoc
 Rule group statements only affect the current rule group and last from the line they were defined until the end of a function block.
 
 ```go
-func _(m fluent.Matcher) {
+func testGroup(m fluent.Matcher) {
 	// <- Empty imports table.
 
 	m.Import(`github.com/some/pkg`)

--- a/ruleguard/parser.go
+++ b/ruleguard/parser.go
@@ -238,6 +238,9 @@ func (p *rulesParser) parseRuleGroup(f *ast.FuncDecl) (err error) {
 		panic(rv) // not our panic
 	}()
 
+	if f.Name.String() == "_" {
+		return p.errorf(f.Name, "`_` is not a valid rule group function name")
+	}
 	if f.Body == nil {
 		return p.errorf(f, "unexpected empty function body")
 	}

--- a/rules.go
+++ b/rules.go
@@ -21,10 +21,7 @@ import "github.com/quasilyte/go-ruleguard/dsl/fluent"
 //
 // If you want to report any issue, please do so: https://github.com/quasilyte/go-ruleguard/issues/new
 
-// "_" is a special "unnamed" rules group.
-// It's not a good style to use these, but it can be a convenient place for
-// various rules for which you can't find a good name.
-func _(m fluent.Matcher) {
+func miscRules(m fluent.Matcher) {
 	// See http://golang.org/issue/36225
 	m.Match(`json.NewDecoder($_).Decode($_)`).
 		Report(`this json.Decoder usage is erroneous`)


### PR DESCRIPTION
This feature was a mistake.
All rule groups should have a good name.

github.com/dgryski/semgrep-go doesn't use "_" rule groups,
so this breaking change should be tolerable.

We're getting closer to the 1.0, but we're not there yet.