### PR TITLE
ruleguard: remove unused severity field

### DIFF
--- a/ruleguard/gorule.go
+++ b/ruleguard/gorule.go
@@ -17,7 +17,6 @@ type goRule struct {
 	group      string
 	filename   string
 	line       int
-	severity   string
 	pat        *gogrep.Pattern
 	msg        string
 	location   string

--- a/ruleguard/runner.go
+++ b/ruleguard/runner.go
@@ -158,11 +158,7 @@ func (rr *rulesRunner) handleMatch(rule goRule, m gogrep.MatchData) bool {
 		}
 	}
 
-	prefix := ""
-	if rule.severity != "" {
-		prefix = rule.severity + ": "
-	}
-	message := prefix + rr.renderMessage(rule.msg, m.Node, m.Values, true)
+	message := rr.renderMessage(rule.msg, m.Node, m.Values, true)
 	node := m.Node
 	if rule.location != "" {
 		node = m.Values[rule.location]


### PR DESCRIPTION
We don't have any severity levels yet and there is 0
user requests for them.