### PR TITLE
ruleguard,analyzer: add -debug-imports flag

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -22,20 +22,26 @@ var Analyzer = &analysis.Analyzer{
 }
 
 var (
-	flagRules string
-	flagE     string
-	flagDebug string
+	flagRules        string
+	flagE            string
+	flagDebug        string
+	flagDebugImports bool
 )
 
 func init() {
 	Analyzer.Flags.StringVar(&flagRules, "rules", "", "comma-separated list of gorule file paths")
 	Analyzer.Flags.StringVar(&flagE, "e", "", "execute a single rule from a given string")
 	Analyzer.Flags.StringVar(&flagDebug, "debug-group", "", "enable debug for the specified function")
+	Analyzer.Flags.BoolVar(&flagDebugImports, "debug-imports", false, "enable debug for rules compile-time package lookups")
 }
 
 type parseRulesResult struct {
 	rset      *ruleguard.GoRuleSet
 	multiFile bool
+}
+
+func debugPrint(s string) {
+	fmt.Fprintln(os.Stderr, s)
 }
 
 func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
@@ -50,14 +56,12 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 	multiFile := parseResult.multiFile
 
 	ctx := &ruleguard.Context{
-		Debug: flagDebug,
-		DebugPrint: func(s string) {
-			fmt.Fprintln(os.Stderr, s)
-		},
-		Pkg:   pass.Pkg,
-		Types: pass.TypesInfo,
-		Sizes: pass.TypesSizes,
-		Fset:  pass.Fset,
+		Debug:      flagDebug,
+		DebugPrint: debugPrint,
+		Pkg:        pass.Pkg,
+		Types:      pass.TypesInfo,
+		Sizes:      pass.TypesSizes,
+		Fset:       pass.Fset,
 		Report: func(info ruleguard.GoRuleInfo, n ast.Node, msg string, s *ruleguard.Suggestion) {
 			msg = info.Group + ": " + msg
 			if multiFile {
@@ -97,6 +101,12 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 func readRules() (*parseRulesResult, error) {
 	fset := token.NewFileSet()
 
+	ctx := &ruleguard.ParseContext{
+		Fset:         fset,
+		DebugImports: flagDebugImports,
+		DebugPrint:   debugPrint,
+	}
+
 	switch {
 	case flagRules != "":
 		filenames := strings.Split(flagRules, ",")
@@ -108,7 +118,7 @@ func readRules() (*parseRulesResult, error) {
 			if err != nil {
 				return nil, fmt.Errorf("read rules file: %v", err)
 			}
-			rset, err := ruleguard.ParseRules(filename, fset, bytes.NewReader(data))
+			rset, err := ruleguard.ParseRules(ctx, filename, bytes.NewReader(data))
 			if err != nil {
 				return nil, fmt.Errorf("parse rules file: %v", err)
 			}
@@ -132,7 +142,7 @@ func readRules() (*parseRulesResult, error) {
 			}`,
 			flagE)
 		r := strings.NewReader(ruleText)
-		rset, err := ruleguard.ParseRules(flagRules, fset, r)
+		rset, err := ruleguard.ParseRules(ctx, flagRules, r)
 		return &parseRulesResult{rset: rset}, err
 
 	default:

--- a/ruleguard/debug_test.go
+++ b/ruleguard/debug_test.go
@@ -150,8 +150,8 @@ func TestDebug(t *testing.T) {
 				%s.Report("$$")
 			}`,
 			s)
-		fset := token.NewFileSet()
-		rset, err := ParseRules("rules.go", fset, strings.NewReader(file))
+		ctx := &ParseContext{Fset: token.NewFileSet()}
+		rset, err := ParseRules(ctx, "rules.go", strings.NewReader(file))
 		if err != nil {
 			t.Fatalf("parse %s: %v", s, err)
 		}

--- a/ruleguard/importer.go
+++ b/ruleguard/importer.go
@@ -1,12 +1,14 @@
 package ruleguard
 
 import (
+	"fmt"
 	"go/ast"
 	"go/importer"
 	"go/parser"
 	"go/token"
 	"go/types"
 	"path/filepath"
+	"runtime"
 
 	"github.com/quasilyte/go-ruleguard/internal/golist"
 )
@@ -15,6 +17,8 @@ import (
 // It iterates through multiple import strategies and accepts whatever succeeds first.
 type goImporter struct {
 	// TODO(quasilyte): share importers with gogrep?
+
+	ctx *ParseContext
 
 	// cache contains all imported packages, from any importer.
 	// Both default and source importers have their own caches,
@@ -28,29 +32,38 @@ type goImporter struct {
 	srcImporter     types.Importer
 }
 
-func newGoImporter(fset *token.FileSet) *goImporter {
+func newGoImporter(ctx *ParseContext) *goImporter {
 	return &goImporter{
+		ctx:             ctx,
 		cache:           make(map[string]*types.Package),
-		fset:            fset,
 		defaultImporter: importer.Default(),
-		srcImporter:     importer.ForCompiler(fset, "source", nil),
+		srcImporter:     importer.ForCompiler(ctx.Fset, "source", nil),
 	}
 }
 
 func (imp *goImporter) Import(path string) (*types.Package, error) {
 	if pkg := imp.cache[path]; pkg != nil {
+		if imp.ctx.DebugImports {
+			imp.ctx.DebugPrint(fmt.Sprintf(`imported "%s" from importer cache`, path))
+		}
 		return pkg, nil
 	}
 
-	pkg, err1 := imp.defaultImporter.Import(path)
+	pkg, err1 := imp.srcImporter.Import(path)
 	if err1 == nil {
 		imp.cache[path] = pkg
+		if imp.ctx.DebugImports {
+			imp.ctx.DebugPrint(fmt.Sprintf(`imported "%s" from source importer`, path))
+		}
 		return pkg, nil
 	}
 
-	pkg, err2 := imp.srcImporter.Import(path)
+	pkg, err2 := imp.defaultImporter.Import(path)
 	if err2 == nil {
 		imp.cache[path] = pkg
+		if imp.ctx.DebugImports {
+			imp.ctx.DebugPrint(fmt.Sprintf(`imported "%s" from %s importer`, path, runtime.Compiler))
+		}
 		return pkg, nil
 	}
 
@@ -58,12 +71,20 @@ func (imp *goImporter) Import(path string) (*types.Package, error) {
 	pkg, err3 := imp.golistImport(path)
 	if err3 == nil {
 		imp.cache[path] = pkg
+		if imp.ctx.DebugImports {
+			imp.ctx.DebugPrint(fmt.Sprintf(`imported "%s" from golist importer`, path))
+		}
 		return pkg, nil
 	}
 
-	// TODO: report all err1, err2 and err3 in debug mode.
+	if imp.ctx.DebugImports {
+		imp.ctx.DebugPrint(fmt.Sprintf(`failed to import "%s":`, path))
+		imp.ctx.DebugPrint(fmt.Sprintf("  source importer: %v", err1))
+		imp.ctx.DebugPrint(fmt.Sprintf("  %s importer: %v", runtime.Compiler, err2))
+		imp.ctx.DebugPrint(fmt.Sprintf("  golist importer: %v", err3))
+	}
 
-	return nil, err1
+	return nil, err2
 }
 
 func (imp *goImporter) golistImport(path string) (*types.Package, error) {

--- a/ruleguard/ruleguard.go
+++ b/ruleguard/ruleguard.go
@@ -9,6 +9,13 @@ import (
 	"github.com/quasilyte/go-ruleguard/ruleguard/typematch"
 )
 
+type ParseContext struct {
+	DebugImports bool
+	DebugPrint   func(string)
+
+	Fset *token.FileSet
+}
+
 type Context struct {
 	Debug      string
 	DebugPrint func(string)
@@ -26,13 +33,14 @@ type Suggestion struct {
 	Replacement []byte
 }
 
-func ParseRules(filename string, fset *token.FileSet, r io.Reader) (*GoRuleSet, error) {
+func ParseRules(ctx *ParseContext, filename string, r io.Reader) (*GoRuleSet, error) {
 	config := rulesParserConfig{
+		ctx:      ctx,
 		itab:     typematch.NewImportsTab(stdlibPackages),
-		importer: newGoImporter(fset),
+		importer: newGoImporter(ctx),
 	}
 	p := newRulesParser(config)
-	return p.ParseFile(filename, fset, r)
+	return p.ParseFile(filename, r)
 }
 
 func RunRules(ctx *Context, f *ast.File, rules *GoRuleSet) error {

--- a/ruleguard/ruleguard_test.go
+++ b/ruleguard/ruleguard_test.go
@@ -49,8 +49,8 @@ func TestParseRuleError(t *testing.T) {
 				%s
 			}`,
 			test.expr)
-		fset := token.NewFileSet()
-		_, err := ParseRules("rules.go", fset, strings.NewReader(file))
+		ctx := &ParseContext{Fset: token.NewFileSet()}
+		_, err := ParseRules(ctx, "rules.go", strings.NewReader(file))
 		if err == nil {
 			t.Errorf("parse %s: expected %s error, got none", test.expr, test.err)
 			continue
@@ -138,8 +138,8 @@ func TestParseFilterError(t *testing.T) {
 				m.Match("$x + $y[$key]").Where(%s).Report("$$")
 			}`,
 			test.expr)
-		fset := token.NewFileSet()
-		_, err := ParseRules("rules.go", fset, strings.NewReader(file))
+		ctx := &ParseContext{Fset: token.NewFileSet()}
+		_, err := ParseRules(ctx, "rules.go", strings.NewReader(file))
 		if err == nil {
 			t.Errorf("parse %s: expected %s error, got none", test.expr, test.err)
 			continue


### PR DESCRIPTION
Allows to debug rules compile-time import issues.