### PR TITLE
analyzer: add -enable and -disable flags

### DIFF
--- a/_test/install/gitclone/expected3.txt
+++ b/_test/install/gitclone/expected3.txt
@@ -1,0 +1,3 @@
+/root/target.go:8:10: exprUnparen: the parentheses around 1 are superfluous (rules2.go:15)
+/root/target.go:9:10: exprUnparen: the parentheses around 2 are superfluous (rules2.go:15)
+/root/target.go:11:10: testrules/boolComparison: omit bool literal in expression (rules1.go:8)

--- a/_test/install/gitclone/expected4.txt
+++ b/_test/install/gitclone/expected4.txt
@@ -1,0 +1,1 @@
+/root/target.go:12:10: testrules/boolExprSimplify: suggestion: b (rules2.go:6)

--- a/_test/install/gitclone/test.bash
+++ b/_test/install/gitclone/test.bash
@@ -16,4 +16,10 @@ go get -v -u github.com/quasilyte/ruleguard-rules-test
 ./go-ruleguard -rules /root/rules2.go /root/target.go &> actual.txt || true
 diff -u actual.txt /root/expected2.txt
 
+./go-ruleguard -disable 'testrules/boolExprSimplify' -rules /root/rules2.go /root/target.go &> actual.txt || true
+diff -u actual.txt /root/expected3.txt
+
+./go-ruleguard -enable 'testrules/boolExprSimplify' -rules /root/rules2.go /root/target.go &> actual.txt || true
+diff -u actual.txt /root/expected4.txt
+
 echo SUCCESS

--- a/ruleguard/parser.go
+++ b/ruleguard/parser.go
@@ -253,6 +253,9 @@ func (p *rulesParser) parseRuleGroup(f *ast.FuncDecl) (err error) {
 		p.group = p.prefix + "/" + f.Name.Name
 	}
 
+	if p.ctx.GroupFilter != nil && !p.ctx.GroupFilter(p.group) {
+		return nil // Skip this group
+	}
 	if _, ok := p.res.groups[p.group]; ok {
 		panic(fmt.Sprintf("duplicated function %s after the typecheck", p.group)) // Should never happen
 	}

--- a/ruleguard/ruleguard.go
+++ b/ruleguard/ruleguard.go
@@ -13,6 +13,12 @@ type ParseContext struct {
 	DebugImports bool
 	DebugPrint   func(string)
 
+	// GroupFilter is called for every rule group being parsed.
+	// If function returns false, that group will not be included
+	// in the resulting rules set.
+	// Nil filter accepts all rule groups.
+	GroupFilter func(string) bool
+
 	Fset *token.FileSet
 }
 


### PR DESCRIPTION
`-enable` and `-disable` are a comma separated lists.
It's not very convenient to specify a long list in bash,
but since most configuration is done in yaml (golangci-lint),
it should be somewhat readable:

	disable: >-
		A,
		B,
		C

Another option:

	disable: "\
		A,\
		B,\
		C"

Useful in combination with ruleguard modules.
Rules from modules can be disabled via -disable flag.

Both `-enable` and `-disable` flags can be debugged with
`-debug-enable-disable `flag (prints whether a group was enabled/disabled).

Refs #149