### PR TITLE
_test/install: add 2 tests for go modules based install

### DIFF
--- a/_test/install/gitclone_nobuildtag/Dockerfile
+++ b/_test/install/gitclone_nobuildtag/Dockerfile
@@ -1,0 +1,5 @@
+FROM golang:1.15.6-alpine AS build
+
+COPY . /root
+
+RUN /root/test.bash

--- a/_test/install/gitclone_nobuildtag/expected.txt
+++ b/_test/install/gitclone_nobuildtag/expected.txt
@@ -1,0 +1,6 @@
+/root/src/target.go:10:10: exprUnparen: the parentheses around 1 are superfluous (rules.go:20)
+/root/src/target.go:11:10: exprUnparen: the parentheses around 2 are superfluous (rules.go:20)
+/root/src/target.go:13:10: testrules/boolComparison: omit bool literal in expression (rules1.go:8)
+/root/src/target.go:14:10: testrules/boolExprSimplify: suggestion: b (rules2.go:6)
+/root/src/target.go:20:10: sprintStringer: can use foo.String() directly (rules.go:26)
+/root/src/target.go:21:10: sprintStringer: can use fooptr.String() directly (rules.go:26)

--- a/_test/install/gitclone_nobuildtag/expected2.txt
+++ b/_test/install/gitclone_nobuildtag/expected2.txt
@@ -1,0 +1,2 @@
+/root/src/target.go:10:10: e: add((1), 2)
+/root/src/target.go:11:10: e: add(1, (2))

--- a/_test/install/gitclone_nobuildtag/rules.go
+++ b/_test/install/gitclone_nobuildtag/rules.go
@@ -1,0 +1,29 @@
+package gorules
+
+import (
+	"github.com/quasilyte/go-ruleguard/dsl"
+	"github.com/quasilyte/go-ruleguard/dsl/types"
+	testrules "github.com/quasilyte/ruleguard-rules-test"
+)
+
+func init() {
+	dsl.ImportRules("testrules", testrules.Bundle)
+}
+
+func implementsStringer(ctx *dsl.VarFilterContext) bool {
+	stringer := ctx.GetInterface(`fmt.Stringer`)
+	return types.Implements(ctx.Type, stringer) ||
+		types.Implements(types.NewPointer(ctx.Type), stringer)
+}
+
+func exprUnparen(m dsl.Matcher) {
+	m.Match(`$f($*_, ($x), $*_)`).
+		Report(`the parentheses around $x are superfluous`).
+		Suggest(`$f($x)`)
+}
+
+func sprintStringer(m dsl.Matcher) {
+	m.Match(`fmt.Sprint($x)`).
+		Where(m["x"].Filter(implementsStringer) && m["x"].Addressable).
+		Report(`can use $x.String() directly`)
+}

--- a/_test/install/gitclone_nobuildtag/src/target.go
+++ b/_test/install/gitclone_nobuildtag/src/target.go
@@ -1,0 +1,27 @@
+package target
+
+import "fmt"
+
+func add(x, y int) int {
+	return x + y
+}
+
+func test(b bool) {
+	println(add((1), 2))
+	println(add(1, (2)))
+
+	println(b == true)
+	println(!!b)
+
+	var foo Foo
+	fooptr := &Foo{}
+
+	println(fmt.Sprint(0))
+	println(fmt.Sprint(foo))
+	println(fmt.Sprint(fooptr))
+	println(fmt.Sprint(&foo))
+}
+
+type Foo struct{}
+
+func (Foo) String() string { return "Foo" }

--- a/_test/install/gitclone_nobuildtag/test.bash
+++ b/_test/install/gitclone_nobuildtag/test.bash
@@ -1,0 +1,25 @@
+set -e
+
+apk update && apk add git
+
+export GO111MODULE=on
+
+# Build go-ruleguard.
+git clone https://github.com/quasilyte/go-ruleguard.git /root/go-ruleguard
+cd /root/go-ruleguard
+go build -o go-ruleguard ./cmd/ruleguard
+
+cd /root
+go mod init test
+
+go mod tidy
+cat go.mod | grep 'github.com/quasilyte/go-ruleguard/dsl'
+echo 'OK: DSL is still in go.mod'
+
+/root/go-ruleguard/go-ruleguard -rules /root/rules.go /root/src/target.go &> actual.txt || true
+diff -u actual.txt /root/expected.txt
+
+/root/go-ruleguard/go-ruleguard -e 'm.Match(`$f($*_, ($x), $*_)`)' /root/src/target.go &> actual.txt || true
+diff -u actual.txt /root/expected2.txt
+
+echo SUCCESS

--- a/_test/install/gitclone_toolsgo/Dockerfile
+++ b/_test/install/gitclone_toolsgo/Dockerfile
@@ -1,0 +1,5 @@
+FROM golang:1.15.6-alpine AS build
+
+COPY . /root
+
+RUN /root/test.bash

--- a/_test/install/gitclone_toolsgo/expected.txt
+++ b/_test/install/gitclone_toolsgo/expected.txt
@@ -1,0 +1,6 @@
+/root/src/target.go:10:10: exprUnparen: the parentheses around 1 are superfluous (rules.go:22)
+/root/src/target.go:11:10: exprUnparen: the parentheses around 2 are superfluous (rules.go:22)
+/root/src/target.go:13:10: testrules/boolComparison: omit bool literal in expression (rules1.go:8)
+/root/src/target.go:14:10: testrules/boolExprSimplify: suggestion: b (rules2.go:6)
+/root/src/target.go:20:10: sprintStringer: can use foo.String() directly (rules.go:28)
+/root/src/target.go:21:10: sprintStringer: can use fooptr.String() directly (rules.go:28)

--- a/_test/install/gitclone_toolsgo/expected2.txt
+++ b/_test/install/gitclone_toolsgo/expected2.txt
@@ -1,0 +1,2 @@
+/root/src/target.go:10:10: e: add((1), 2)
+/root/src/target.go:11:10: e: add(1, (2))

--- a/_test/install/gitclone_toolsgo/rules.go
+++ b/_test/install/gitclone_toolsgo/rules.go
@@ -1,0 +1,31 @@
+// +build ignore
+
+package gorules
+
+import (
+	"github.com/quasilyte/go-ruleguard/dsl"
+	"github.com/quasilyte/go-ruleguard/dsl/types"
+	testrules "github.com/quasilyte/ruleguard-rules-test"
+)
+
+func init() {
+	dsl.ImportRules("testrules", testrules.Bundle)
+}
+
+func implementsStringer(ctx *dsl.VarFilterContext) bool {
+	stringer := ctx.GetInterface(`fmt.Stringer`)
+	return types.Implements(ctx.Type, stringer) ||
+		types.Implements(types.NewPointer(ctx.Type), stringer)
+}
+
+func exprUnparen(m dsl.Matcher) {
+	m.Match(`$f($*_, ($x), $*_)`).
+		Report(`the parentheses around $x are superfluous`).
+		Suggest(`$f($x)`)
+}
+
+func sprintStringer(m dsl.Matcher) {
+	m.Match(`fmt.Sprint($x)`).
+		Where(m["x"].Filter(implementsStringer) && m["x"].Addressable).
+		Report(`can use $x.String() directly`)
+}

--- a/_test/install/gitclone_toolsgo/src/target.go
+++ b/_test/install/gitclone_toolsgo/src/target.go
@@ -1,0 +1,27 @@
+package target
+
+import "fmt"
+
+func add(x, y int) int {
+	return x + y
+}
+
+func test(b bool) {
+	println(add((1), 2))
+	println(add(1, (2)))
+
+	println(b == true)
+	println(!!b)
+
+	var foo Foo
+	fooptr := &Foo{}
+
+	println(fmt.Sprint(0))
+	println(fmt.Sprint(foo))
+	println(fmt.Sprint(fooptr))
+	println(fmt.Sprint(&foo))
+}
+
+type Foo struct{}
+
+func (Foo) String() string { return "Foo" }

--- a/_test/install/gitclone_toolsgo/test.bash
+++ b/_test/install/gitclone_toolsgo/test.bash
@@ -1,0 +1,25 @@
+set -e
+
+apk update && apk add git
+
+export GO111MODULE=on
+
+# Build go-ruleguard.
+git clone https://github.com/quasilyte/go-ruleguard.git /root/go-ruleguard
+cd /root/go-ruleguard
+go build -o go-ruleguard ./cmd/ruleguard
+
+cd /root
+go mod init test
+
+go mod tidy
+cat go.mod | grep 'github.com/quasilyte/go-ruleguard/dsl'
+echo 'OK: DSL is still in go.mod'
+
+/root/go-ruleguard/go-ruleguard -rules /root/rules.go /root/src/target.go &> actual.txt || true
+diff -u actual.txt /root/expected.txt
+
+/root/go-ruleguard/go-ruleguard -e 'm.Match(`$f($*_, ($x), $*_)`)' /root/src/target.go &> actual.txt || true
+diff -u actual.txt /root/expected2.txt
+
+echo SUCCESS

--- a/_test/install/gitclone_toolsgo/tools.go
+++ b/_test/install/gitclone_toolsgo/tools.go
@@ -1,0 +1,7 @@
+// +build tools
+
+package tools
+
+import (
+	_ "github.com/quasilyte/go-ruleguard/dsl"
+)


### PR DESCRIPTION
Other tests add `github.com/quasilyte/go-ruleguard/dsl` as indirect
dependency, which may not be what people want as it may go
away after `go mod tidy`.

There are at least 2 ways to avoid that:

1. Use a `tools.go` idiom https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module

2. Do not add a `// +build ignore` tag to the `rules.go` file

Two new tests check that these options work as intended.