### PR TITLE
analyzer: add optional version info (only when built with Make)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,14 @@
 GOPATH_DIR=`go env GOPATH`
 RELEASE=v0.2.1
+BUILD_COMMIT=`git rev-parse HEAD`
+
+build:
+	mkdir -p bin
+	go build -o bin/ruleguard -ldflags "-X 'github.com/quasilyte/go-ruleguard/analyzer.Version=$(BUILD_COMMIT)'" ./cmd/ruleguard
+
+build-release:
+	mkdir -p bin
+	go build -o bin/ruleguard -ldflags "-X 'github.com/quasilyte/go-ruleguard/analyzer.Version=$(RELEASE)'" ./cmd/ruleguard
 
 test:
 	go test -count 3 -coverprofile=coverage.txt -covermode=atomic -race -v ./analyzer/...
@@ -25,4 +34,4 @@ lint:
 	./go-ruleguard -rules rules.go ./analyzer/... ./ruleguard/...
 	@echo "everything is OK"
 
-.PHONY: lint test test-master
+.PHONY: lint test test-master build build-release

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -15,10 +15,23 @@ import (
 	"golang.org/x/tools/go/analysis"
 )
 
+// Version contains extra version info.
+// It's is initialized via ldflags -X when ruleguard is built with Make.
+// Can contain a git hash (dev builds) or a version tag (release builds).
+var Version string
+
+func docString() string {
+	doc := "execute dynamic gogrep-based rules"
+	if Version == "" {
+		return doc
+	}
+	return doc + " (" + Version + ")"
+}
+
 // Analyzer exports ruleguard as a analysis-compatible object.
 var Analyzer = &analysis.Analyzer{
 	Name: "ruleguard",
-	Doc:  "execute dynamic gogrep-based rules",
+	Doc:  docString(),
 	Run:  runAnalyzer,
 }
 


### PR DESCRIPTION
`make build` is used for normal dev builds.
`make release` is used to prepare the release binaries.

Refs #179