### PR TITLE
analyzer: don't print "e: " prefix in `-e` mode

### DIFF
--- a/_test/install/gitclone/expected5.txt
+++ b/_test/install/gitclone/expected5.txt
@@ -1,2 +1,2 @@
-/root/target.go:10:10: e: add((1), 2)
-/root/target.go:11:10: e: add(1, (2))
+/root/target.go:10:10: add((1), 2)
+/root/target.go:11:10: add(1, (2))

--- a/_test/install/gitclone_nobuildtag/expected2.txt
+++ b/_test/install/gitclone_nobuildtag/expected2.txt
@@ -1,2 +1,2 @@
-/root/src/target.go:10:10: e: add((1), 2)
-/root/src/target.go:11:10: e: add(1, (2))
+/root/src/target.go:10:10: add((1), 2)
+/root/src/target.go:11:10: add(1, (2))

--- a/_test/install/gitclone_toolsgo/expected2.txt
+++ b/_test/install/gitclone_toolsgo/expected2.txt
@@ -1,2 +1,2 @@
-/root/src/target.go:10:10: e: add((1), 2)
-/root/src/target.go:11:10: e: add(1, (2))
+/root/src/target.go:10:10: add((1), 2)
+/root/src/target.go:11:10: add(1, (2))

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -96,9 +96,10 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 		Sizes:        pass.TypesSizes,
 		Fset:         pass.Fset,
 		Report: func(info ruleguard.GoRuleInfo, n ast.Node, msg string, s *ruleguard.Suggestion) {
-			fullMessage := info.Group + ": " + msg
+			fullMessage := msg
 			if printRuleLocation {
-				fullMessage += fmt.Sprintf(" (%s:%d)", filepath.Base(info.Filename), info.Line)
+				fullMessage = fmt.Sprintf("%s: %s (%s:%d)",
+					info.Group, msg, filepath.Base(info.Filename), info.Line)
 			}
 			diag := analysis.Diagnostic{
 				Pos:     n.Pos(),


### PR DESCRIPTION
Fixes #188