### PR TITLE
gogrep: add non-strict literal matching

### DIFF
--- a/analyzer/testdata/src/extra/file.go
+++ b/analyzer/testdata/src/extra/file.go
@@ -2,6 +2,7 @@ package extra
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -432,4 +433,9 @@ func redundantLenCheck(xs []int, v int) {
 			println(v)
 		}
 	}
+}
+
+func emptyError() {
+	_ = errors.New("") // want `empty error`
+	_ = errors.New(``) // want `empty error`
 }

--- a/analyzer/testdata/src/extra/rules.go
+++ b/analyzer/testdata/src/extra/rules.go
@@ -162,4 +162,6 @@ func testRules(m dsl.Matcher) {
 		`if $xs != nil { for _, $x := range $xs { $*_ } }`,
 		`if $xs != nil { for _, $x = range $xs { $*_ } }`).
 		Report(`check on $xs is redundant, empty/nil slices and maps can be safely iterated`)
+
+	m.Match(`errors.New("")`).Report(`empty error`)
 }

--- a/internal/mvdan.cc/gogrep/gogrep.go
+++ b/internal/mvdan.cc/gogrep/gogrep.go
@@ -9,8 +9,8 @@ type StmtList = stmtList
 type ExprList = exprList
 
 // Parse creates a gogrep pattern out of a given string expression.
-func Parse(fset *token.FileSet, expr string) (*Pattern, error) {
-	m := matcher{fset: fset}
+func Parse(fset *token.FileSet, expr string, strict bool) (*Pattern, error) {
+	m := matcher{fset: fset, strict: strict}
 	node, err := m.parseExpr(expr)
 	if err != nil {
 		return nil, err

--- a/ruleguard/parser.go
+++ b/ruleguard/parser.go
@@ -450,7 +450,7 @@ func (p *rulesParser) parseRule(matcher string, call *ast.CallExpr) error {
 
 	for i, alt := range alternatives {
 		rule := proto
-		pat, err := gogrep.Parse(p.ctx.Fset, alt)
+		pat, err := gogrep.Parse(p.ctx.Fset, alt, false)
 		if err != nil {
 			return p.errorf((*matchArgs)[i], "parse match pattern: %v", err)
 		}


### PR DESCRIPTION
So the literals that are spelled differently, but have identical
underlying value can be matched.

	"abc" = `abc`
	0x0   = 0
	0b11  = 3
	'\n'  = '0x0a'
	0.01  = .01
	...etc

I'm planning to add a strict matching option for the DSL; but I need some use cases before that to see when it's useful (in which contexts and for what purpose). By default, all patterns are non-strict.