### PR TITLE
rules: add emptyError rule

### DIFF
--- a/rules/go.mod
+++ b/rules/go.mod
@@ -3,7 +3,7 @@ module github.com/quasilyte/go-ruleguard/rules
 go 1.15
 
 require (
-	github.com/quasilyte/go-ruleguard v0.2.2-0.20201231192024-946f92c70294
-	github.com/quasilyte/go-ruleguard/dsl v0.0.0-20201231192024-946f92c70294
+	github.com/quasilyte/go-ruleguard v0.3.1-0.20210203134552-1b5a410e1cc8
+	github.com/quasilyte/go-ruleguard/dsl v0.3.0
 	golang.org/x/tools v0.0.0-20201230224404-63754364767c
 )

--- a/rules/go.sum
+++ b/rules/go.sum
@@ -3,9 +3,13 @@ github.com/quasilyte/go-ruleguard v0.2.1 h1:56eRm0daAyny9UhJnmtJW/UyLZQusukBAB8o
 github.com/quasilyte/go-ruleguard v0.2.1/go.mod h1:hN2rVc/uS4bQhQKTio2XaSJSafJwqBUWWwtssT3cQmc=
 github.com/quasilyte/go-ruleguard v0.2.2-0.20201231192024-946f92c70294 h1:mASW/sY/hKIUmVz6K9ramD6KMCApBk1Ds0SLceQTdQ0=
 github.com/quasilyte/go-ruleguard v0.2.2-0.20201231192024-946f92c70294/go.mod h1:W4JcSjEo0rNPJXrbu+tE/q2j1PkPZfNP7S560relvZU=
+github.com/quasilyte/go-ruleguard v0.3.1-0.20210203134552-1b5a410e1cc8 h1:gOIfUEC9GfAbP9afwk9NHiiLP266qOe62rxNQ+pzGBA=
+github.com/quasilyte/go-ruleguard v0.3.1-0.20210203134552-1b5a410e1cc8/go.mod h1:KsAh3x0e7Fkpgs+Q9pNLS5XpFSvYCEVl5gP9Pp1xp30=
 github.com/quasilyte/go-ruleguard/dsl v0.0.0-20201222100711-8bb37f2dbd8a/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
 github.com/quasilyte/go-ruleguard/dsl v0.0.0-20201231192024-946f92c70294 h1:tPeLso6EUWBr7Dy0aJHvT+7OalbSYS7/HGRDNHtXTGs=
 github.com/quasilyte/go-ruleguard/dsl v0.0.0-20201231192024-946f92c70294/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
+github.com/quasilyte/go-ruleguard/dsl v0.3.0 h1:+KRgVKXGdkhPCJdHD3rszyiuFHmMy/avI+FaLxVJ3gw=
+github.com/quasilyte/go-ruleguard/dsl v0.3.0/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
 github.com/quasilyte/go-ruleguard/rules v0.0.0-20201231183845-9e62ed36efe1/go.mod h1:7JTjp89EGyU1d6XfBiXihJNG37wB2VRkd125Q1u7Plc=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/rules/style.go
+++ b/rules/style.go
@@ -15,3 +15,8 @@ func emptyDecl(m dsl.Matcher) {
 	m.Match(`const()`).Report(`empty const() block`)
 	m.Match(`type()`).Report(`empty type() block`)
 }
+
+func emptyError(m dsl.Matcher) {
+	m.Match(`fmt.Errorf("")`, `errors.New("")`).
+		Report(`empty errors are hard to debug`)
+}

--- a/rules/testdata/style.go
+++ b/rules/testdata/style.go
@@ -1,5 +1,10 @@
 package target
 
+import (
+	"errors"
+	"fmt"
+)
+
 func exprUnparen() {
 	var f func(args ...interface{})
 
@@ -12,4 +17,11 @@ func emptyDecl() {
 	var ()   // want `\QemptyDecl: empty var() block`
 	const () // want `\QemptyDecl: empty const() block`
 	type ()  // want `\QemptyDecl: empty type() block`
+}
+
+func emptyError() {
+	_ = fmt.Errorf("") // want `\Qempty errors are hard to debug`
+	_ = fmt.Errorf(``) // want `\Qempty errors are hard to debug`
+	_ = errors.New("") // want `\Qempty errors are hard to debug`
+	_ = errors.New(``) // want `\Qempty errors are hard to debug`
 }


### PR DESCRIPTION
Give a warning for these patterns:

	fmt.Errorf("")
	errors.New("")