### PR TITLE
gogrep: use slices instead of maps for capture data

### DIFF
--- a/internal/mvdan.cc/gogrep/gogrep_perf_test.go
+++ b/internal/mvdan.cc/gogrep/gogrep_perf_test.go
@@ -1,0 +1,76 @@
+package gogrep
+
+import (
+	"go/token"
+	"testing"
+)
+
+func BenchmarkMatch(b *testing.B) {
+	tests := []struct {
+		name  string
+		pat   string
+		input string
+	}{
+		{
+			name:  `simpleLit`,
+			pat:   `true`,
+			input: `true`,
+		},
+		{
+			name:  `capture1`,
+			pat:   `+$x`,
+			input: `+50`,
+		},
+		{
+			name:  `capture2`,
+			pat:   `$x + $y`,
+			input: `x + 4`,
+		},
+		{
+			name:  `capture8`,
+			pat:   `f($x1, $x2, $x3, $x4, $x5, $x6, $x7, $x8)`,
+			input: `f(1, 2, 3, 4, 5, 6, 7, 8)`,
+		},
+		{
+			name:  `capture2same`,
+			pat:   `$x + $x`,
+			input: `a + a`,
+		},
+		{
+			name:  `capture8same`,
+			pat:   `f($x, $x, $x, $x, $x, $x, $x, $x)`,
+			input: `f(1, 1, 1, 1, 1, 1, 1, 1)`,
+		},
+		{
+			name:  `captureBacktrackLeft`,
+			pat:   `f($*xs, $y)`,
+			input: `f(1, 2, 3, 4, 5, 6)`,
+		},
+		{
+			name:  `captureBacktrackRight`,
+			pat:   `f($x, $*ys)`,
+			input: `f(1, 2, 3, 4, 5, 6)`,
+		},
+	}
+
+	for i := range tests {
+		test := tests[i]
+		b.Run(test.name, func(b *testing.B) {
+			fset := token.NewFileSet()
+			pat, err := Parse(fset, test.pat, true)
+			if err != nil {
+				b.Errorf("parse `%s`: %v", test.pat, err)
+				return
+			}
+			target := testParseNode(b, test.input)
+			if err != nil {
+				b.Errorf("parse target `%s`: %v", test.input, err)
+				return
+			}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				testAllMatches(pat, target, func(m MatchData) {})
+			}
+		})
+	}
+}

--- a/internal/mvdan.cc/gogrep/gogrep_test.go
+++ b/internal/mvdan.cc/gogrep/gogrep_test.go
@@ -149,8 +149,8 @@ func TestCapture(t *testing.T) {
 			}
 			capture := vars{}
 			pat.MatchNode(target, func(m MatchData) {
-				for k, n := range m.Values {
-					capture[k] = sprintNode(n)
+				for _, c := range m.Capture {
+					capture[c.Name] = sprintNode(c.Node)
 				}
 			})
 			if diff := cmp.Diff(capture, test.capture); diff != "" {
@@ -623,7 +623,7 @@ func testAllMatches(p *Pattern, target ast.Node, cb func(MatchData)) {
 	})
 }
 
-func testParseNode(t *testing.T, s string) ast.Node {
+func testParseNode(t testing.TB, s string) ast.Node {
 	if strings.HasPrefix(s, "package ") {
 		file, err := parser.ParseFile(token.NewFileSet(), "string", s, 0)
 		if err != nil {

--- a/ruleguard/filters.go
+++ b/ruleguard/filters.go
@@ -224,7 +224,8 @@ func makeTextFilter(src, varname string, op token.Token, rhsVarname string) filt
 	return func(params *filterParams) matchFilterResult {
 		s1 := params.nodeText(params.subExpr(varname))
 		lhsValue := constant.MakeString(string(s1))
-		s2 := params.nodeText(params.values[rhsVarname])
+		n, _ := params.match.CapturedByName(rhsVarname)
+		s2 := params.nodeText(n)
 		rhsValue := constant.MakeString(string(s2))
 		if constant.Compare(lhsValue, op, rhsValue) {
 			return filterSuccess

--- a/ruleguard/gorule.go
+++ b/ruleguard/gorule.go
@@ -53,7 +53,7 @@ type filterParams struct {
 
 	importer *goImporter
 
-	values map[string]ast.Node
+	match gogrep.MatchData
 
 	nodeText func(n ast.Node) []byte
 
@@ -62,7 +62,8 @@ type filterParams struct {
 }
 
 func (params *filterParams) subExpr(name string) ast.Expr {
-	switch n := params.values[name].(type) {
+	n, _ := params.match.CapturedByName(name)
+	switch n := n.(type) {
 	case ast.Expr:
 		return n
 	case *ast.ExprStmt:

--- a/ruleguard/ruleguard_test.go
+++ b/ruleguard/ruleguard_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/quasilyte/go-ruleguard/internal/mvdan.cc/gogrep"
 )
 
 func TestRenderMessage(t *testing.T) {
@@ -89,12 +90,19 @@ func TestRenderMessage(t *testing.T) {
 		Fset: token.NewFileSet(),
 	}
 	for _, test := range tests {
-		nodes := make(map[string]ast.Node, len(test.vars))
-		for _, v := range test.vars {
-			nodes[v] = &ast.Ident{Name: v + "var"}
+		capture := make([]gogrep.CapturedNode, len(test.vars))
+		for i, v := range test.vars {
+			capture[i] = gogrep.CapturedNode{
+				Name: v,
+				Node: &ast.Ident{Name: v + "var"},
+			}
 		}
 
-		have := rr.renderMessage(test.msg, &ast.Ident{Name: "dd"}, nodes, false)
+		m := gogrep.MatchData{
+			Node:    &ast.Ident{Name: "dd"},
+			Capture: capture,
+		}
+		have := rr.renderMessage(test.msg, m, false)
 		if diff := cmp.Diff(have, test.want); diff != "" {
 			t.Errorf("render %s %v:\n(+want -have)\n%s", test.msg, test.vars, diff)
 		}


### PR DESCRIPTION
Since most patterns have less than 8 variables (usually, 1-4),
it's more efficient to use key-value slices instead of maps.
They also make memory reusing easier.

Even for 8 vars, slices are more efficient here.

```
name                           old time/op    new time/op    delta
Match/simpleLit-8                 217ns ± 3%     123ns ± 4%  -43.33%  (p=0.008 n=5+5)
Match/capture1-8                  652ns ± 7%     275ns ± 2%  -57.79%  (p=0.008 n=5+5)
Match/capture2-8                  950ns ± 0%     438ns ± 1%  -53.84%  (p=0.008 n=5+5)
Match/capture8-8                 3.89µs ± 5%    2.51µs ± 0%  -35.57%  (p=0.008 n=5+5)
Match/capture2same-8              947ns ± 2%     458ns ± 6%  -51.68%  (p=0.008 n=5+5)
Match/capture8same-8             3.42µs ± 2%    2.31µs ± 2%  -32.36%  (p=0.008 n=5+5)
Match/captureBacktrackLeft-8     5.87µs ± 1%    4.43µs ± 1%  -24.60%  (p=0.008 n=5+5)
Match/captureBacktrackRight-8    4.80µs ± 0%    2.43µs ± 3%  -49.42%  (p=0.008 n=5+5)

name                           old alloc/op   new alloc/op   delta
Match/simpleLit-8                 80.0B ± 0%     32.0B ± 0%  -60.00%  (p=0.008 n=5+5)
Match/capture1-8                   416B ± 0%       32B ± 0%  -92.31%  (p=0.008 n=5+5)
Match/capture2-8                   464B ± 0%       32B ± 0%  -93.10%  (p=0.008 n=5+5)
Match/capture8-8                   896B ± 0%      128B ± 0%  -85.71%  (p=0.008 n=5+5)
Match/capture2same-8               464B ± 0%       32B ± 0%  -93.10%  (p=0.008 n=5+5)
Match/capture8same-8               896B ± 0%      128B ± 0%  -85.71%  (p=0.008 n=5+5)
Match/captureBacktrackLeft-8     2.75kB ± 0%    0.85kB ± 0%  -69.19%  (p=0.008 n=5+5)
Match/captureBacktrackRight-8    2.54kB ± 0%    0.43kB ± 0%  -83.02%  (p=0.008 n=5+5)

name                           old allocs/op  new allocs/op  delta
Match/simpleLit-8                  2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.008 n=5+5)
Match/capture1-8                   4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.008 n=5+5)
Match/capture2-8                   5.00 ± 0%      1.00 ± 0%  -80.00%  (p=0.008 n=5+5)
Match/capture8-8                   15.0 ± 0%       4.0 ± 0%  -73.33%  (p=0.008 n=5+5)
Match/capture2same-8               5.00 ± 0%      1.00 ± 0%  -80.00%  (p=0.008 n=5+5)
Match/capture8same-8               15.0 ± 0%       4.0 ± 0%  -73.33%  (p=0.008 n=5+5)
Match/captureBacktrackLeft-8       31.0 ± 0%      21.0 ± 0%  -32.26%  (p=0.008 n=5+5)
Match/captureBacktrackRight-8      25.0 ± 0%      12.0 ± 0%  -52.00%  (p=0.008 n=5+5)
```