### PR TITLE
Change %v to %w so we can call Unwrap

### DIFF
--- a/ruleguard/parser.go
+++ b/ruleguard/parser.go
@@ -88,7 +88,7 @@ func (p *rulesParser) ParseFile(filename string, r io.Reader) (*goRuleSet, error
 	for _, imp := range f.Imports {
 		importPath, err := strconv.Unquote(imp.Path.Value)
 		if err != nil {
-			return nil, p.errorf(imp, "unquote %s import path: %w", imp.Path.Value, err)
+			return nil, p.errorf(imp, "unquote %s import path: %v", imp.Path.Value, err)
 		}
 		if importPath == "github.com/quasilyte/go-ruleguard/dsl" {
 			if imp.Name != nil {
@@ -227,12 +227,12 @@ func (p *rulesParser) parseInitFunc(f *ast.FuncDecl) error {
 	for _, imp := range imported {
 		files, err := findBundleFiles(imp.pkgPath)
 		if err != nil {
-			return p.errorf(imp.node, "import lookup error: %w", err)
+			return p.errorf(imp.node, "import lookup error: %v", err)
 		}
 		for _, filename := range files {
 			rset, err := p.importRules(imp.prefix, imp.pkgPath, filename)
 			if err != nil {
-				return p.errorf(imp.node, "import parsing error: %w", err)
+				return p.errorf(imp.node, "import parsing error: %v", err)
 			}
 			p.imported = append(p.imported, rset)
 		}

--- a/ruleguard/parser.go
+++ b/ruleguard/parser.go
@@ -22,9 +22,7 @@ import (
 
 // TODO(quasilyte): use source code byte slicing instead of SprintNode?
 
-type parseError string
-
-func (e parseError) Error() string { return string(e) }
+type parseError error
 
 type rulesParser struct {
 	state *engineState
@@ -473,8 +471,7 @@ func (p *rulesParser) parseFilter(root ast.Expr) matchFilter {
 
 func (p *rulesParser) errorf(n ast.Node, err error) parseError {
 	loc := p.ctx.Fset.Position(n.Pos())
-	message := fmt.Sprintf("%s:%d: %w", loc.Filename, loc.Line, err)
-	return parseError(message)
+	return parseError(fmt.Errorf("%s:%d: %w", loc.Filename, loc.Line, err))
 }
 
 func (p *rulesParser) parseStringArg(e ast.Expr) string {

--- a/ruleguard/parser.go
+++ b/ruleguard/parser.go
@@ -26,8 +26,8 @@ type parseError error
 
 // ImportError is returned when a ruleguard file references a package that cannot be imported.
 type ImportError struct {
-  msg string
-  err error
+	msg string
+	err error
 }
 
 func (e *ImportError) Error() string { return e.msg }

--- a/ruleguard/parser.go
+++ b/ruleguard/parser.go
@@ -24,7 +24,7 @@ import (
 
 type parseError error
 
-// ImportError is returned when a package cannot be imported.
+// ImportError is returned when a ruleguard file references a package that cannot be imported.
 type ImportError struct {
   msg string
   err error

--- a/ruleguard/parser.go
+++ b/ruleguard/parser.go
@@ -2,7 +2,7 @@ package ruleguard
 
 import (
 	"bytes"
-  "errors"
+	"errors"
 	"fmt"
 	"go/ast"
 	"go/parser"
@@ -352,7 +352,7 @@ func (p *rulesParser) parseStmt(fn *ast.Ident, args []ast.Expr) error {
 		p.itab.Load(pkgName, pkgPath)
 		return nil
 	default:
-		return p.errorf(fn,  fmt.Errorf("unexpected %s method", fn.Name))
+		return p.errorf(fn, fmt.Errorf("unexpected %s method", fn.Name))
 	}
 }
 

--- a/ruleguard/parser.go
+++ b/ruleguard/parser.go
@@ -22,7 +22,7 @@ import (
 
 // TODO(quasilyte): use source code byte slicing instead of SprintNode?
 
-type parseError error
+type parseError struct{ error }
 
 // ImportError is returned when a ruleguard file references a package that cannot be imported.
 type ImportError struct {
@@ -480,7 +480,7 @@ func (p *rulesParser) parseFilter(root ast.Expr) matchFilter {
 
 func (p *rulesParser) errorf(n ast.Node, err error) parseError {
 	loc := p.ctx.Fset.Position(n.Pos())
-	return parseError(fmt.Errorf("%s:%d: %w", loc.Filename, loc.Line, err))
+	return parseError{fmt.Errorf("%s:%d: %w", loc.Filename, loc.Line, err)}
 }
 
 func (p *rulesParser) parseStringArg(e ast.Expr) string {

--- a/ruleguard/parser.go
+++ b/ruleguard/parser.go
@@ -24,6 +24,15 @@ import (
 
 type parseError error
 
+// ImportError is returned when a package cannot be imported.
+type ImportError struct {
+  msg string
+  err error
+}
+
+func (e *ImportError) Error() string { return e.msg }
+func (e *ImportError) Unwrap() error { return e.err }
+
 type rulesParser struct {
 	state *engineState
 	ctx   *ParseContext
@@ -680,7 +689,7 @@ func (p *rulesParser) toInterfaceValue(x ast.Node) *types.Interface {
 	}
 	pkg, err := p.importer.Import(pkgPath)
 	if err != nil {
-		panic(p.errorf(n, fmt.Errorf("can't load %s: %w", pkgPath, err)))
+		panic(p.errorf(n, &ImportError{msg: fmt.Sprintf("can't load %s", pkgPath), err: err}))
 	}
 	obj := pkg.Scope().Lookup(qn.Sel.Name)
 	if obj == nil {


### PR DESCRIPTION
1. Changed parseError such that errors can be unwrapped if needed.
2. Create a sentinel ImportError such that callers can identify specific package import errors

Main change  is https://github.com/quasilyte/go-ruleguard/pull/217/files#diff-26106e9ba3277b0a6fb3ec1c696f2b4007d5b6c133575a2aa893b1260d5c7bd5R481-R483

This will make it possible to selectively process ruleguard errors in go-critic. In particular, this should make it possible to decide whether to skip or fail on parse error. I will raise a separate PR in go-critic.

This should help address https://github.com/quasilyte/go-ruleguard/issues/215