### PR TITLE
ruleguard: use parseError.error field for the returned error

### DIFF
--- a/ruleguard/parser.go
+++ b/ruleguard/parser.go
@@ -283,7 +283,7 @@ func (p *rulesParser) parseRuleGroup(f *ast.FuncDecl) (err error) {
 			return
 		}
 		if parseErr, ok := rv.(parseError); ok {
-			err = parseErr
+			err = parseErr.error
 			return
 		}
 		panic(rv) // not our panic


### PR DESCRIPTION
So we actually return an `*ImportError` instead of `*parseError`
which can't be examined on the caller side.