### PR TITLE
ruleguard: add Engine.LoadedGroups method

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -99,7 +99,7 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 			fullMessage := msg
 			if printRuleLocation {
 				fullMessage = fmt.Sprintf("%s: %s (%s:%d)",
-					info.Group, msg, filepath.Base(info.Group.Filename), info.Line)
+					info.Group.Name, msg, filepath.Base(info.Group.Filename), info.Line)
 			}
 			diag := analysis.Diagnostic{
 				Pos:     n.Pos(),

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/go-toolsmith/astequal v1.0.0
 	github.com/google/go-cmp v0.5.2
 	github.com/quasilyte/go-ruleguard/dsl v0.3.2
-	github.com/quasilyte/go-ruleguard/rules v0.0.0-20210203162857-b223e0831f88
+	github.com/quasilyte/go-ruleguard/rules v0.0.0-20210428214800-545e0d2e0bf7
 	golang.org/x/tools v0.0.0-20201230224404-63754364767c
 )

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/quasilyte/go-ruleguard/rules v0.0.0-20201231183845-9e62ed36efe1 h1:PX
 github.com/quasilyte/go-ruleguard/rules v0.0.0-20201231183845-9e62ed36efe1/go.mod h1:7JTjp89EGyU1d6XfBiXihJNG37wB2VRkd125Q1u7Plc=
 github.com/quasilyte/go-ruleguard/rules v0.0.0-20210203162857-b223e0831f88 h1:PeTrJiH/dSeruL/Z9Db39NRMwI/yoA3oHCdCkg+Wh8A=
 github.com/quasilyte/go-ruleguard/rules v0.0.0-20210203162857-b223e0831f88/go.mod h1:4cgAphtvu7Ftv7vOT2ZOYhC6CvBxZixcasr8qIOTA50=
+github.com/quasilyte/go-ruleguard/rules v0.0.0-20210428214800-545e0d2e0bf7 h1:cRLFDAB53r5wIkxYvtQUMnn3+B09uZTAOPmefNfVk5I=
+github.com/quasilyte/go-ruleguard/rules v0.0.0-20210428214800-545e0d2e0bf7/go.mod h1:4cgAphtvu7Ftv7vOT2ZOYhC6CvBxZixcasr8qIOTA50=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/ruleguard/engine.go
+++ b/ruleguard/engine.go
@@ -6,6 +6,7 @@ import (
 	"go/ast"
 	"go/types"
 	"io"
+	"sort"
 	"strings"
 	"sync"
 
@@ -23,6 +24,17 @@ func newEngine() *engine {
 	return &engine{
 		state: newEngineState(),
 	}
+}
+
+func (e *engine) LoadedGroups() []GoRuleGroup {
+	result := make([]GoRuleGroup, 0, len(e.ruleSet.groups))
+	for _, g := range e.ruleSet.groups {
+		result = append(result, *g)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+	return result
 }
 
 func (e *engine) Load(ctx *ParseContext, filename string, r io.Reader) error {

--- a/ruleguard/ruleguard.go
+++ b/ruleguard/ruleguard.go
@@ -34,6 +34,11 @@ func (e *Engine) Load(ctx *ParseContext, filename string, r io.Reader) error {
 	return e.impl.Load(ctx, filename, r)
 }
 
+// LoadedGroups returns information about all currently loaded rule groups.
+func (e *Engine) LoadedGroups() []GoRuleGroup {
+	return e.impl.LoadedGroups()
+}
+
 // Run executes all loaded rules on a given file.
 // Matched rules invoke `RunContext.Report()` method.
 //
@@ -86,6 +91,13 @@ type GoRuleInfo struct {
 type GoRuleGroup struct {
 	// Name is a function name associated with this rule group.
 	Name string
+
+	// Pos is a location where this rule group was defined.
+	Pos token.Position
+
+	// Line is a source code line number inside associated file.
+	// A pair of Filename:Line form a conventional location string.
+	Line int
 
 	// Filename is a file that defined this rule group.
 	Filename string

--- a/ruleguard/runner.go
+++ b/ruleguard/runner.go
@@ -199,7 +199,7 @@ func (rr *rulesRunner) reject(rule goRule, reason string, m matchData) {
 
 	pos := rr.ctx.Fset.Position(m.Node().Pos())
 	rr.ctx.DebugPrint(fmt.Sprintf("%s:%d: [%s:%d] rejected by %s",
-		pos.Filename, pos.Line, filepath.Base(rule.filename), rule.line, reason))
+		pos.Filename, pos.Line, filepath.Base(rule.group.Filename), rule.line, reason))
 
 	values := make([]gogrep.CapturedNode, len(m.CaptureList()))
 	copy(values, m.CaptureList())


### PR DESCRIPTION
It returns the sorted slice of the groups that have been
loaded so far.