### PR TITLE
ruleguard: handle variadic vars in filters properly

### DIFF
--- a/analyzer/testdata/src/filtertest/rules.go
+++ b/analyzer/testdata/src/filtertest/rules.go
@@ -35,6 +35,12 @@ func testRules(m dsl.Matcher) {
 		Where(!m["x"].Type.Is(`int`)).
 		Report(`$x !is(int)`)
 
+	m.Match(`typeTest($*xs, "variadic int")`).Where(m["xs"].Type.Is(`int`)).Report(`true`)
+	m.Match(`typeTest($*xs, "variadic int")`).Where(!m["xs"].Type.Is(`int`)).Report(`false`)
+
+	m.Match(`typeTest($*xs, "variadic underlying int")`).Where(m["xs"].Type.Underlying().Is(`int`)).Report(`true`)
+	m.Match(`typeTest($*xs, "variadic underlying int")`).Where(!m["xs"].Type.Underlying().Is(`int`)).Report(`false`)
+
 	m.Match(`typeTest($x > $y)`).
 		Where(!m["x"].Type.Is(`string`) && m["x"].Pure).
 		Report(`$x !is(string) && pure`)
@@ -53,6 +59,14 @@ func testRules(m dsl.Matcher) {
 		Where(m["x"].Type.Implements(`foolib.Stringer`)).Report(`YES`)
 	m.Match(`typeTest($x, "implements error")`).
 		Where(m["x"].Type.Implements(`error`)).Report(`YES`)
+
+	m.Match(`typeTest($*xs, "variadic implements error")`).
+		Where(m["xs"].Type.Implements(`error`)).Report(`true`)
+	m.Match(`typeTest($*xs, "variadic implements error")`).
+		Where(!m["xs"].Type.Implements(`error`)).Report(`false`)
+
+	m.Match(`typeTest($*xs, "variadic size==4")`).Where(m["xs"].Type.Size == 4).Report(`true`)
+	m.Match(`typeTest($*xs, "variadic size==4")`).Where(!(m["xs"].Type.Size == 4)).Report(`false`)
 
 	m.Match(`typeTest($x, "size>=100")`).Where(m["x"].Type.Size >= 100).Report(`YES`)
 	m.Match(`typeTest($x, "size<=100")`).Where(m["x"].Type.Size <= 100).Report(`YES`)
@@ -78,11 +92,39 @@ func testRules(m dsl.Matcher) {
 
 	m.Match(`pureTest($x)`).
 		Where(m["x"].Pure).
-		Report("pure")
+		Report("true")
 
 	m.Match(`pureTest($x)`).
 		Where(!m["x"].Pure).
-		Report("!pure")
+		Report("false")
+
+	m.Match(`pureTest($*xs, "variadic pure")`).
+		Where(m["xs"].Pure).
+		Report("true")
+
+	m.Match(`pureTest($*xs, "variadic pure")`).
+		Where(!m["xs"].Pure).
+		Report("false")
+
+	m.Match(`constTest($*xs, "variadic const")`).
+		Where(m["xs"].Const).
+		Report("true")
+
+	m.Match(`constTest($*xs, "variadic const")`).
+		Where(!m["xs"].Const).
+		Report("false")
+
+	m.Match(`typeTest($*xs, "variadic addressable")`).Where(m["xs"].Addressable).Report("true")
+	m.Match(`typeTest($*xs, "variadic addressable")`).Where(!m["xs"].Addressable).Report("false")
+
+	m.Match(`typeTest($*xs, "variadic convertible to string")`).Where(m["xs"].Type.ConvertibleTo(`string`)).Report("true")
+	m.Match(`typeTest($*xs, "variadic convertible to string")`).Where(!m["xs"].Type.ConvertibleTo(`string`)).Report("false")
+
+	m.Match(`typeTest($*xs, "variadic assignable to string")`).Where(m["xs"].Type.AssignableTo(`string`)).Report("true")
+	m.Match(`typeTest($*xs, "variadic assignable to string")`).Where(!m["xs"].Type.AssignableTo(`string`)).Report("false")
+
+	m.Match(`valueTest($*xs, "variadic value 5")`).Where(m["xs"].Value.Int() == 5).Report(`true`)
+	m.Match(`valueTest($*xs, "variadic value 5")`).Where(!(m["xs"].Value.Int() == 5)).Report(`false`)
 
 	m.Match(`lineTest($x, "line 4")`).Where(m["x"].Line == 4).Report(`YES`)
 	m.Match(`lineTest($x, $y, "same line")`).Where(m["x"].Line == m["y"].Line).Report(`YES`)

--- a/analyzer/testdata/src/filtertest/utils.go
+++ b/analyzer/testdata/src/filtertest/utils.go
@@ -2,12 +2,14 @@ package filtertest
 
 func typeTest(args ...interface{})         {}
 func pureTest(args ...interface{})         {}
+func constTest(args ...interface{})        {}
 func textTest(args ...interface{})         {}
 func parensFilterTest(args ...interface{}) {}
 func importsTest(args ...interface{})      {}
 func fileTest(args ...interface{})         {}
 func nodeTest(args ...interface{})         {}
 func lineTest(args ...interface{})         {}
+func valueTest(args ...interface{})        {}
 
 func random() int {
 	return 42

--- a/internal/gogrep/compile.go
+++ b/internal/gogrep/compile.go
@@ -112,7 +112,7 @@ func (c *compiler) compileNode(n ast.Node) {
 		c.compileValueSpec(n)
 	case stmtSlice:
 		c.compileStmtSlice(n)
-	case exprSlice:
+	case ExprSlice:
 		c.compileExprSlice(n)
 	default:
 		panic(c.errorf(n, "compileNode: unexpected %T", n))
@@ -971,7 +971,7 @@ func (c *compiler) compileStmtSlice(stmts stmtSlice) {
 	c.emitInstOp(opEnd)
 }
 
-func (c *compiler) compileExprSlice(exprs exprSlice) {
+func (c *compiler) compileExprSlice(exprs ExprSlice) {
 	c.emitInstOp(opMultiExpr)
 	for _, n := range exprs {
 		c.compileExpr(n)

--- a/internal/gogrep/gogrep.go
+++ b/internal/gogrep/gogrep.go
@@ -8,8 +8,8 @@ import (
 )
 
 func IsEmptyNodeSlice(n ast.Node) bool {
-	if list, ok := n.(nodeSlice); ok {
-		return list.len() == 0
+	if list, ok := n.(NodeSlice); ok {
+		return list.Len() == 0
 	}
 	return false
 }

--- a/internal/gogrep/match.go
+++ b/internal/gogrep/match.go
@@ -76,15 +76,15 @@ func (m *matcher) MatchNode(n ast.Node, accept func(MatchData)) {
 }
 
 func (m *matcher) walkExprSlice(exprs []ast.Expr, accept func(MatchData)) {
-	m.walkNodeSlice(exprSlice(exprs), accept)
+	m.walkNodeSlice(ExprSlice(exprs), accept)
 }
 
 func (m *matcher) walkStmtSlice(stmts []ast.Stmt, accept func(MatchData)) {
 	m.walkNodeSlice(stmtSlice(stmts), accept)
 }
 
-func (m *matcher) walkNodeSlice(nodes nodeSlice, accept func(MatchData)) {
-	sliceLen := nodes.len()
+func (m *matcher) walkNodeSlice(nodes NodeSlice, accept func(MatchData)) {
+	sliceLen := nodes.Len()
 	from := 0
 	for {
 		m.pc = 1 // FIXME: this is a kludge
@@ -506,7 +506,7 @@ func (m *matcher) matchStmtSlice(stmts []ast.Stmt) bool {
 }
 
 func (m *matcher) matchExprSlice(exprs []ast.Expr) bool {
-	matched, _ := m.matchNodeList(exprSlice(exprs), false)
+	matched, _ := m.matchNodeList(ExprSlice(exprs), false)
 	return matched != nil
 }
 
@@ -527,8 +527,8 @@ func (m *matcher) matchSpecSlice(specs []ast.Spec) bool {
 
 // matchNodeList matches two lists of nodes. It uses a common algorithm to match
 // wildcard patterns with any number of nodes without recursion.
-func (m *matcher) matchNodeList(nodes nodeSlice, partial bool) (ast.Node, int) {
-	sliceLen := nodes.len()
+func (m *matcher) matchNodeList(nodes NodeSlice, partial bool) (ast.Node, int) {
+	sliceLen := nodes.Len()
 	inst := m.nextInst()
 	if inst.op == opEnd {
 		if sliceLen == 0 {
@@ -615,7 +615,7 @@ func (m *matcher) matchNodeList(nodes nodeSlice, partial bool) (ast.Node, int) {
 				partialStart = j
 				push(j + 1)
 			}
-			if j < sliceLen && wouldMatch() && m.matchNodeWithInst(inst, nodes.at(j)) {
+			if j < sliceLen && wouldMatch() && m.matchNodeWithInst(inst, nodes.At(j)) {
 				// ordinary match
 				wildName = ""
 				j++
@@ -699,8 +699,8 @@ func equalNodes(x, y ast.Node) bool {
 			}
 		}
 		return true
-	case exprSlice:
-		y, ok := y.(exprSlice)
+	case ExprSlice:
+		y, ok := y.(ExprSlice)
 		if !ok || len(x) != len(y) {
 			return false
 		}

--- a/internal/gogrep/parse.go
+++ b/internal/gogrep/parse.go
@@ -170,7 +170,7 @@ func parseDetectingNode(fset *token.FileSet, src string) (ast.Node, *ast.File, e
 		if len(cl.Elts) == 1 {
 			return cl.Elts[0], f, nil
 		}
-		return exprSlice(cl.Elts), f, nil
+		return ExprSlice(cl.Elts), f, nil
 	}
 
 	// then try as statements

--- a/internal/gogrep/slices.go
+++ b/internal/gogrep/slices.go
@@ -5,47 +5,47 @@ import (
 	"go/token"
 )
 
-type nodeSlice interface {
-	at(i int) ast.Node
-	len() int
-	slice(from, to int) nodeSlice
+type NodeSlice interface {
+	At(i int) ast.Node
+	Len() int
+	slice(from, to int) NodeSlice
 	ast.Node
 }
 
 type (
-	exprSlice  []ast.Expr
+	ExprSlice  []ast.Expr
 	stmtSlice  []ast.Stmt
 	fieldSlice []*ast.Field
 	identSlice []*ast.Ident
 	specSlice  []ast.Spec
 )
 
-func (l exprSlice) len() int                 { return len(l) }
-func (l exprSlice) at(i int) ast.Node        { return l[i] }
-func (l exprSlice) slice(i, j int) nodeSlice { return l[i:j] }
-func (l exprSlice) Pos() token.Pos           { return l[0].Pos() }
-func (l exprSlice) End() token.Pos           { return l[len(l)-1].End() }
+func (l ExprSlice) Len() int                 { return len(l) }
+func (l ExprSlice) At(i int) ast.Node        { return l[i] }
+func (l ExprSlice) slice(i, j int) NodeSlice { return l[i:j] }
+func (l ExprSlice) Pos() token.Pos           { return l[0].Pos() }
+func (l ExprSlice) End() token.Pos           { return l[len(l)-1].End() }
 
-func (l stmtSlice) len() int                 { return len(l) }
-func (l stmtSlice) at(i int) ast.Node        { return l[i] }
-func (l stmtSlice) slice(i, j int) nodeSlice { return l[i:j] }
+func (l stmtSlice) Len() int                 { return len(l) }
+func (l stmtSlice) At(i int) ast.Node        { return l[i] }
+func (l stmtSlice) slice(i, j int) NodeSlice { return l[i:j] }
 func (l stmtSlice) Pos() token.Pos           { return l[0].Pos() }
 func (l stmtSlice) End() token.Pos           { return l[len(l)-1].End() }
 
-func (l fieldSlice) len() int                 { return len(l) }
-func (l fieldSlice) at(i int) ast.Node        { return l[i] }
-func (l fieldSlice) slice(i, j int) nodeSlice { return l[i:j] }
+func (l fieldSlice) Len() int                 { return len(l) }
+func (l fieldSlice) At(i int) ast.Node        { return l[i] }
+func (l fieldSlice) slice(i, j int) NodeSlice { return l[i:j] }
 func (l fieldSlice) Pos() token.Pos           { return l[0].Pos() }
 func (l fieldSlice) End() token.Pos           { return l[len(l)-1].End() }
 
-func (l identSlice) len() int                 { return len(l) }
-func (l identSlice) at(i int) ast.Node        { return l[i] }
-func (l identSlice) slice(i, j int) nodeSlice { return l[i:j] }
+func (l identSlice) Len() int                 { return len(l) }
+func (l identSlice) At(i int) ast.Node        { return l[i] }
+func (l identSlice) slice(i, j int) NodeSlice { return l[i:j] }
 func (l identSlice) Pos() token.Pos           { return l[0].Pos() }
 func (l identSlice) End() token.Pos           { return l[len(l)-1].End() }
 
-func (l specSlice) len() int                 { return len(l) }
-func (l specSlice) at(i int) ast.Node        { return l[i] }
-func (l specSlice) slice(i, j int) nodeSlice { return l[i:j] }
+func (l specSlice) Len() int                 { return len(l) }
+func (l specSlice) At(i int) ast.Node        { return l[i] }
+func (l specSlice) slice(i, j int) NodeSlice { return l[i:j] }
 func (l specSlice) Pos() token.Pos           { return l[0].Pos() }
 func (l specSlice) End() token.Pos           { return l[len(l)-1].End() }

--- a/ruleguard/utils.go
+++ b/ruleguard/utils.go
@@ -179,7 +179,7 @@ func isPure(info *types.Info, expr ast.Expr) bool {
 	case *ast.UnaryExpr:
 		return expr.Op != token.ARROW &&
 			isPure(info, expr.X)
-	case *ast.BasicLit, *ast.Ident:
+	case *ast.BasicLit, *ast.Ident, *ast.FuncLit:
 		return true
 	case *ast.IndexExpr:
 		return isPure(info, expr.X) &&


### PR DESCRIPTION
For patterns like `f($*args)` we can now apply a
`m["args"].Pure` filter to check whether **all** arguments are pure.

It works with most filters.

The current implementation is messy, but it will do for now.