### PR TITLE
ruleguard: add parent nodes support for $$

### DIFF
--- a/analyzer/testdata/src/extra/file.go
+++ b/analyzer/testdata/src/extra/file.go
@@ -439,3 +439,28 @@ func emptyError() {
 	_ = errors.New("") // want `empty error`
 	_ = errors.New(``) // want `empty error`
 }
+
+func contextWithValue(ctx context.Context) {
+	type myKey string
+
+	context.WithValue(ctx, myKey(""), 10) // want `\Qcontext.WithValue result should not be ignored`
+
+	_ = context.WithValue(ctx, myKey("b"), "ok")
+	sinkFunc(context.WithValue(ctx, myKey("b"), "ok"))
+}
+
+var MyGlobalError = errors.New("Bad") // want `\Qerror vars should be prefixed with Err`
+
+var ( // want `\Qerror vars should be prefixed with Err`
+	MyGlobalError2 = errors.New("Bad")
+)
+
+func errorDeclTest() {
+	var MyError = errors.New("OK")
+	sinkFunc(MyError)
+
+	{
+		var MyError2 = errors.New("OK")
+		sinkFunc(MyError2)
+	}
+}

--- a/analyzer/testdata/src/extra/rules.go
+++ b/analyzer/testdata/src/extra/rules.go
@@ -164,4 +164,14 @@ func testRules(m dsl.Matcher) {
 		Report(`check on $xs is redundant, empty/nil slices and maps can be safely iterated`)
 
 	m.Match(`errors.New("")`).Report(`empty error`)
+
+	m.Match(`context.WithValue($*_)`).
+		Where(m["$$"].Node.Parent().Is(`ExprStmt`)).
+		Report(`context.WithValue result should not be ignored`)
+
+	m.Match(`var $v = $_`).
+		Where(m["$$"].Node.Parent().Is(`File`) &&
+			m["v"].Type.Implements(`error`) &&
+			!m["v"].Text.Matches(`^Err`)).
+		Report(`error vars should be prefixed with Err`)
 }

--- a/analyzer/testdata/src/extra/utils.go
+++ b/analyzer/testdata/src/extra/utils.go
@@ -2,6 +2,8 @@ package extra
 
 var sink interface{}
 
+func sinkFunc(args ...interface{}) {}
+
 func foo() int { return 19 }
 
 func mightFail() error { return nil }

--- a/analyzer/testdata/src/filtertest/f1.go
+++ b/analyzer/testdata/src/filtertest/f1.go
@@ -419,6 +419,8 @@ func detectText(foo, bar int) {
 
 	textTest(1, "doesn't match [A-Z]") // want `YES`
 	textTest("ABC", "doesn't match [A-Z]")
+
+	textTest("", "root text test") // want `YES`
 }
 
 func detectParensFilter() {

--- a/analyzer/testdata/src/filtertest/rules.go
+++ b/analyzer/testdata/src/filtertest/rules.go
@@ -198,4 +198,8 @@ func testRules(m dsl.Matcher) {
 	m.Match(`typeTest($x, "underlying is interface")`).
 		Where(m["x"].Type.Underlying().Is(`interface{ $*_ }`)).
 		Report(`YES`)
+
+	m.Match(`textTest("", "root text test")`).
+		Where(m["$$"].Text == `textTest("", "root text test")`).
+		Report(`YES`)
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/go-toolsmith/astequal v1.0.0
 	github.com/google/go-cmp v0.5.2
-	github.com/quasilyte/go-ruleguard/dsl v0.3.6
+	github.com/quasilyte/go-ruleguard/dsl v0.3.7
 	github.com/quasilyte/go-ruleguard/rules v0.0.0-20210428214800-545e0d2e0bf7
 	golang.org/x/tools v0.0.0-20201230224404-63754364767c
 )

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/quasilyte/go-ruleguard/dsl v0.3.4 h1:Q+004qp73/PtHO01acMuEWmz24XSaCQj
 github.com/quasilyte/go-ruleguard/dsl v0.3.4/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
 github.com/quasilyte/go-ruleguard/dsl v0.3.6 h1:W2wnISJifyda0x/RXq15Qjrsu9iOhX2gy4+Ku+owylw=
 github.com/quasilyte/go-ruleguard/dsl v0.3.6/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
+github.com/quasilyte/go-ruleguard/dsl v0.3.7 h1:jnz0d3UNaw/TxY9gebxE5kSPR+C6CvSPmXLNoz2gQvw=
+github.com/quasilyte/go-ruleguard/dsl v0.3.7/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
 github.com/quasilyte/go-ruleguard/rules v0.0.0-20201231183845-9e62ed36efe1 h1:PX/E0GYUnSV8vwVfpOUEIBKnPG3KmYunmNOBlL+zDko=
 github.com/quasilyte/go-ruleguard/rules v0.0.0-20201231183845-9e62ed36efe1/go.mod h1:7JTjp89EGyU1d6XfBiXihJNG37wB2VRkd125Q1u7Plc=
 github.com/quasilyte/go-ruleguard/rules v0.0.0-20210203162857-b223e0831f88 h1:PeTrJiH/dSeruL/Z9Db39NRMwI/yoA3oHCdCkg+Wh8A=

--- a/internal/gogrep/gogrep.go
+++ b/internal/gogrep/gogrep.go
@@ -26,6 +26,9 @@ type CapturedNode struct {
 }
 
 func (data MatchData) CapturedByName(name string) (ast.Node, bool) {
+	if name == "$$" {
+		return data.Node, true
+	}
 	return findNamed(data.Capture, name)
 }
 

--- a/ruleguard/filters.go
+++ b/ruleguard/filters.go
@@ -346,23 +346,22 @@ func makeTextMatchesFilter(src, varname string, re *regexp.Regexp) filterFunc {
 	}
 }
 
+func makeRootParentNodeIsFilter(src string, tag nodetag.Value) filterFunc {
+	return func(params *filterParams) matchFilterResult {
+		parent := params.nodePath.Parent()
+		if nodeIs(parent, tag) {
+			return filterSuccess
+		}
+		return filterFailure(src)
+	}
+}
+
 func makeNodeIsFilter(src, varname string, tag nodetag.Value) filterFunc {
 	// TODO(quasilyte): add comment nodes support?
 	// TODO(quasilyte): add variadic support.
 	return func(params *filterParams) matchFilterResult {
 		n := params.subNode(varname)
-		var matched bool
-		switch tag {
-		case nodetag.Expr:
-			_, matched = n.(ast.Expr)
-		case nodetag.Stmt:
-			_, matched = n.(ast.Stmt)
-		case nodetag.Node:
-			_, matched = n.(ast.Node)
-		default:
-			matched = (tag == nodetag.FromNode(n))
-		}
-		if matched {
+		if nodeIs(n, tag) {
 			return filterSuccess
 		}
 		return filterFailure(src)
@@ -432,4 +431,19 @@ func makeObjectIsFilter(src, varname, objectName string) filterFunc {
 		}
 		return filterFailure(src)
 	}
+}
+
+func nodeIs(n ast.Node, tag nodetag.Value) bool {
+	var matched bool
+	switch tag {
+	case nodetag.Expr:
+		_, matched = n.(ast.Expr)
+	case nodetag.Stmt:
+		_, matched = n.(ast.Stmt)
+	case nodetag.Node:
+		matched = true
+	default:
+		matched = (tag == nodetag.FromNode(n))
+	}
+	return matched
 }

--- a/ruleguard/gorule.go
+++ b/ruleguard/gorule.go
@@ -60,7 +60,8 @@ type filterParams struct {
 
 	importer *goImporter
 
-	match matchData
+	match    matchData
+	nodePath *nodePath
 
 	nodeText func(n ast.Node) []byte
 

--- a/ruleguard/ir/filter_op.gen.go
+++ b/ruleguard/ir/filter_op.gen.go
@@ -119,6 +119,9 @@ const (
 	// $Value holds an int64 constant
 	// $Value type: int64
 	FilterIntOp FilterOp = 31
+
+	// m[`$$`].Node.Parent().Is($Args[0])
+	FilterRootNodeParentIsOp FilterOp = 32
 )
 
 var filterOpNames = map[FilterOp]string{
@@ -154,6 +157,7 @@ var filterOpNames = map[FilterOp]string{
 	FilterFilterFuncRefOp:        `FilterFuncRef`,
 	FilterStringOp:               `String`,
 	FilterIntOp:                  `Int`,
+	FilterRootNodeParentIsOp:     `RootNodeParentIs`,
 }
 var filterOpFlags = map[FilterOp]uint64{
 	FilterAndOp:    flagIsBinaryExpr,

--- a/ruleguard/ir/gen_filter_op.go
+++ b/ruleguard/ir/gen_filter_op.go
@@ -64,6 +64,8 @@ func main() {
 
 		{name: "String", comment: "$Value holds a string constant", valueType: "string", flags: flagIsBasicLit},
 		{name: "Int", comment: "$Value holds an int64 constant", valueType: "int64", flags: flagIsBasicLit},
+
+		{name: "RootNodeParentIs", comment: "m[`$$`].Node.Parent().Is($Args[0])"},
 	}
 
 	var buf bytes.Buffer

--- a/ruleguard/irconv/irconv.go
+++ b/ruleguard/irconv/irconv.go
@@ -509,6 +509,12 @@ func (conv *converter) convertFilterExprImpl(e ast.Expr) ir.FilterExpr {
 			return ir.FilterExpr{Op: ir.FilterVarTextMatchesOp, Value: op.varName, Args: args}
 		case "Node.Is":
 			return ir.FilterExpr{Op: ir.FilterVarNodeIsOp, Value: op.varName, Args: args}
+		case "Node.Parent.Is":
+			if op.varName != "$$" {
+				// TODO: remove this restriction.
+				panic(conv.errorf(e.Args[0], "only $$ parent nodes are implemented"))
+			}
+			return ir.FilterExpr{Op: ir.FilterRootNodeParentIsOp, Args: args}
 		case "Object.Is":
 			return ir.FilterExpr{Op: ir.FilterVarObjectIsOp, Value: op.varName, Args: args}
 		case "Type.Is":

--- a/ruleguard/nodepath.go
+++ b/ruleguard/nodepath.go
@@ -1,0 +1,49 @@
+package ruleguard
+
+import (
+	"fmt"
+	"go/ast"
+	"strings"
+)
+
+type nodePath struct {
+	stack []ast.Node
+}
+
+func newNodePath() nodePath {
+	return nodePath{stack: make([]ast.Node, 0, 32)}
+}
+
+func (p nodePath) String() string {
+	parts := make([]string, len(p.stack))
+	for i, n := range p.stack {
+		parts[i] = fmt.Sprintf("%T", n)
+	}
+	return strings.Join(parts, "/")
+}
+
+func (p nodePath) Parent() ast.Node {
+	return p.NthParent(1)
+}
+
+func (p nodePath) Current() ast.Node {
+	return p.NthParent(0)
+}
+
+func (p nodePath) NthParent(n int) ast.Node {
+	index := len(p.stack) - n - 1
+	if index >= 0 {
+		return p.stack[index]
+	}
+	return nil
+}
+
+func (p *nodePath) Len() int { return len(p.stack) }
+
+func (p *nodePath) Push(n ast.Node) {
+	p.stack = append(p.stack, n)
+}
+
+func (p *nodePath) Pop() {
+	p.stack = p.stack[:len(p.stack)-1]
+}

--- a/ruleguard/ruleguard_error_test.go
+++ b/ruleguard/ruleguard_error_test.go
@@ -336,6 +336,16 @@ func TestParseFilterError(t *testing.T) {
 			`m["x"].Node.Is("abc")`,
 			`abc is not a valid go/ast type name`,
 		},
+
+		{
+			`m["x"].Node.Parent().Is("ExprStmt")`,
+			`only $$ parent nodes are implemented`,
+		},
+
+		{
+			`m["$$"].Node.Parent().Is("foo")`,
+			`foo is not a valid go/ast type name`,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Changes:

* Make it possible to refer to `m["$$"]` (root) match node inside Where()
* Implement `m["$$"].Node.Parent()`

I'll implement `Node.Parent()` for arbitrary nodes later.
It would require a more sophisticated approach as it will
involve the runner to climb down the tree (as opposed to
climbing it up when we're searching for `$$` parent).

Fixes #258