### PR TITLE
ruleguard: add deadcode filter

### DIFF
--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -30,6 +30,7 @@ var tests = []struct {
 	{name: "namedtype"},
 	{name: "revive"},
 	{name: "golint"},
+	{name: "govet"},
 	{name: "regression"},
 	{name: "testvendored"},
 	{name: "quasigo"},

--- a/analyzer/testdata/src/govet/file.go
+++ b/analyzer/testdata/src/govet/file.go
@@ -1,0 +1,129 @@
+package golint
+
+import "unsafe"
+
+func shiftOverflow() {
+	var ui8 uint8
+	var i8 int8
+	var ui16 uint16
+	var ui32 uint32
+	var ui64 uint64
+
+	_ = i8 << 1
+	_ = i8 << 4
+	_ = i8 << 7
+	_ = i8 << 8  // want `\Qi8 (8 bits) too small for shift of 8`
+	_ = i8 << 10 // want `\Qi8 (8 bits) too small for shift of 10`
+
+	_ = ui8 << 1
+	_ = ui8 << 4
+	_ = ui8 << 7
+	_ = ui8 << 8  // want `\Qui8 (8 bits) too small for shift of 8`
+	_ = ui8 << 10 // want `\Qui8 (8 bits) too small for shift of 10`
+
+	_ = ui16 << 1
+	_ = ui16 << 4
+	_ = ui16 << 15
+	_ = ui16 << 16 // want `\Qui16 (16 bits) too small for shift of 16`
+	_ = ui16 << 17 // want `\Qui16 (16 bits) too small for shift of 17`
+
+	_ = ui32 << 1
+	_ = ui32 << 4
+	_ = ui32 << 31
+	_ = ui32 << 32 // want `\Qui32 (32 bits) too small for shift of 32`
+	_ = ui32 << 33 // want `\Qui32 (32 bits) too small for shift of 33`
+
+	_ = ui64 << 1
+	_ = ui64 << 4
+	_ = ui64 << 63
+	_ = ui64 << 64       // want `\Qui64 (64 bits) too small for shift of 64`
+	_ = ui64 << (63 + 1) // want `\Qui64 (64 bits) too small for shift of (63 + 1)`
+
+	const oneIf64Bit = ^uint(0) >> 63
+	const constTest2 = ^uint8(0) >> 63
+
+	if false {
+		// deadcode, no warnings
+		_ = ui8 << 8
+	} else {
+		// not a deadcode
+		_ = (ui8 + 1) << 9 // want `\Q(ui8 + 1) (8 bits) too small for shift of 9`
+	}
+
+	if true {
+		// not a deadcode
+		_ = (ui8 + 1) << 9 // want `\Q(ui8 + 1) (8 bits) too small for shift of 9`
+	} else {
+		// deadcode, no warnings
+		_ = ui8 << 8
+	}
+
+	const TEN = 10
+
+	if TEN > 30 {
+		_ = ui8 << 8 // deadcode, no warnings
+	} else if TEN > 20 {
+		_ = ui8 << 8 // deadcode, no warnings
+	} else if TEN > 10 {
+		_ = ui8 << 8 // deadcode, no warnings
+	} else {
+		_ = (ui8 + 1) << 9 // want `\Q(ui8 + 1) (8 bits) too small for shift of 9`
+	}
+
+	if TEN > 30 {
+		_ = ui8 << 8 // deadcode, no warnings
+	} else if TEN > 20 {
+		_ = ui8 << 8 // deadcode, no warnings
+	} else if TEN >= 10 {
+		_ = (ui8 + 1) << 9 // want `\Q(ui8 + 1) (8 bits) too small for shift of 9`
+	} else {
+		_ = (ui8 + 1) << 9 // deadcode, no warnings
+	}
+
+	if TEN == 10 {
+		_ = (ui8 + 1) << 9 // want `\Q(ui8 + 1) (8 bits) too small for shift of 9`
+	} else if TEN == 11 {
+		_ = (ui8 + 1) << 9 // deadcode, no warnings
+	} else {
+		_ = (ui8 + 1) << 9 // deadcode, no warnings
+	}
+
+	if TEN == 15 {
+		if TEN > 0 {
+			_ = (ui8 + 1) << 9 // deadcode, no warnings
+			if TEN == 10 {
+				_ = (ui8 + 1) << 9 // deadcode, no warnings
+			}
+		} else {
+			_ = (ui8 + 1) << 9 // deadcode, no warnings
+		}
+	}
+}
+
+func ShiftDeadCode2() {
+	var i int
+	const iBits = 8 * unsafe.Sizeof(i)
+
+	if iBits <= 32 {
+		if iBits == 16 {
+			_ = i >> 8
+		} else {
+			_ = i >> 16
+		}
+	} else {
+		_ = i >> 32
+	}
+
+	if iBits >= 64 {
+		_ = i << 32
+		if iBits == 128 {
+			_ = i << 64
+		}
+	} else {
+		_ = i << 16
+	}
+
+	if iBits == 64 {
+		_ = i << 32
+	}
+}

--- a/analyzer/testdata/src/govet/rules.go
+++ b/analyzer/testdata/src/govet/rules.go
@@ -1,0 +1,23 @@
+// +build ignore
+
+package gorules
+
+import "github.com/quasilyte/go-ruleguard/dsl"
+
+func shiftOverflow(m dsl.Matcher) {
+	m.Match(`$x << $n`).
+		Where(!m["x"].Const && m["x"].Type.Size == 1 && m["n"].Value.Int() >= 8 && !m.Deadcode()).
+		Report(`$x (8 bits) too small for shift of $n`)
+
+	m.Match(`$x << $n`).
+		Where(!m["x"].Const && m["x"].Type.Size == 2 && m["n"].Value.Int() >= 16 && !m.Deadcode()).
+		Report(`$x (16 bits) too small for shift of $n`)
+
+	m.Match(`$x << $n`).
+		Where(!m["x"].Const && m["x"].Type.Size == 4 && m["n"].Value.Int() >= 32 && !m.Deadcode()).
+		Report(`$x (32 bits) too small for shift of $n`)
+	
+	m.Match(`$x << $n`).
+		Where(!m["x"].Const && m["x"].Type.Size == 8 && m["n"].Value.Int() >= 64 && !m.Deadcode()).
+		Report(`$x (64 bits) too small for shift of $n`)
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-toolsmith/astequal v1.0.0
 	github.com/go-toolsmith/strparse v1.0.0 // indirect
 	github.com/google/go-cmp v0.5.2
-	github.com/quasilyte/go-ruleguard/dsl v0.3.8
+	github.com/quasilyte/go-ruleguard/dsl v0.3.9
 	github.com/quasilyte/go-ruleguard/rules v0.0.0-20210428214800-545e0d2e0bf7
 	golang.org/x/tools v0.0.0-20201230224404-63754364767c
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/quasilyte/go-ruleguard v0.3.1-0.20210203134552-1b5a410e1cc8/go.mod h1
 github.com/quasilyte/go-ruleguard/dsl v0.3.0/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
 github.com/quasilyte/go-ruleguard/dsl v0.3.8 h1:QVckSrF3bljZbRIcPNF7gPuRXi7wfFdKu8WNT1R8PwU=
 github.com/quasilyte/go-ruleguard/dsl v0.3.8/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
+github.com/quasilyte/go-ruleguard/dsl v0.3.9 h1:v0TweMVMPfW0RQr0e0erQuehUIIYt97WRAimrU20wyo=
+github.com/quasilyte/go-ruleguard/dsl v0.3.9/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
 github.com/quasilyte/go-ruleguard/rules v0.0.0-20201231183845-9e62ed36efe1/go.mod h1:7JTjp89EGyU1d6XfBiXihJNG37wB2VRkd125Q1u7Plc=
 github.com/quasilyte/go-ruleguard/rules v0.0.0-20210428214800-545e0d2e0bf7 h1:cRLFDAB53r5wIkxYvtQUMnn3+B09uZTAOPmefNfVk5I=
 github.com/quasilyte/go-ruleguard/rules v0.0.0-20210428214800-545e0d2e0bf7/go.mod h1:4cgAphtvu7Ftv7vOT2ZOYhC6CvBxZixcasr8qIOTA50=

--- a/ruleguard/ast_walker.go
+++ b/ruleguard/ast_walker.go
@@ -1,0 +1,322 @@
+package ruleguard
+
+import (
+	"go/ast"
+	"go/constant"
+)
+
+type astWalker struct {
+	nodePath *nodePath
+
+	filterParams *filterParams
+
+	visit func(ast.Node)
+}
+
+func (w *astWalker) Walk(root ast.Node, visit func(ast.Node)) {
+	w.visit = visit
+	w.walk(root)
+}
+
+func (w *astWalker) walkIdentList(list []*ast.Ident) {
+	for _, x := range list {
+		w.walk(x)
+	}
+}
+
+func (w *astWalker) walkExprList(list []ast.Expr) {
+	for _, x := range list {
+		w.walk(x)
+	}
+}
+
+func (w *astWalker) walkStmtList(list []ast.Stmt) {
+	for _, x := range list {
+		w.walk(x)
+	}
+}
+
+func (w *astWalker) walkDeclList(list []ast.Decl) {
+	for _, x := range list {
+		w.walk(x)
+	}
+}
+
+func (w *astWalker) walk(n ast.Node) {
+	w.nodePath.Push(n)
+	defer w.nodePath.Pop()
+
+	w.visit(n)
+
+	switch n := n.(type) {
+	case *ast.Field:
+		// TODO: handle field types.
+		// See #252
+		w.walkIdentList(n.Names)
+		w.walk(n.Type)
+
+	case *ast.FieldList:
+		for _, f := range n.List {
+			w.walk(f)
+		}
+
+	case *ast.Ellipsis:
+		if n.Elt != nil {
+			w.walk(n.Elt)
+		}
+
+	case *ast.FuncLit:
+		w.walk(n.Type)
+		w.walk(n.Body)
+
+	case *ast.CompositeLit:
+		if n.Type != nil {
+			w.walk(n.Type)
+		}
+		w.walkExprList(n.Elts)
+
+	case *ast.ParenExpr:
+		w.walk(n.X)
+
+	case *ast.SelectorExpr:
+		w.walk(n.X)
+		w.walk(n.Sel)
+
+	case *ast.IndexExpr:
+		w.walk(n.X)
+		w.walk(n.Index)
+
+	case *ast.SliceExpr:
+		w.walk(n.X)
+		if n.Low != nil {
+			w.walk(n.Low)
+		}
+		if n.High != nil {
+			w.walk(n.High)
+		}
+		if n.Max != nil {
+			w.walk(n.Max)
+		}
+
+	case *ast.TypeAssertExpr:
+		w.walk(n.X)
+		if n.Type != nil {
+			w.walk(n.Type)
+		}
+
+	case *ast.CallExpr:
+		w.walk(n.Fun)
+		w.walkExprList(n.Args)
+
+	case *ast.StarExpr:
+		w.walk(n.X)
+
+	case *ast.UnaryExpr:
+		w.walk(n.X)
+
+	case *ast.BinaryExpr:
+		w.walk(n.X)
+		w.walk(n.Y)
+
+	case *ast.KeyValueExpr:
+		w.walk(n.Key)
+		w.walk(n.Value)
+
+	case *ast.ArrayType:
+		if n.Len != nil {
+			w.walk(n.Len)
+		}
+		w.walk(n.Elt)
+
+	case *ast.StructType:
+		w.walk(n.Fields)
+
+	case *ast.FuncType:
+		if n.Params != nil {
+			w.walk(n.Params)
+		}
+		if n.Results != nil {
+			w.walk(n.Results)
+		}
+
+	case *ast.InterfaceType:
+		w.walk(n.Methods)
+
+	case *ast.MapType:
+		w.walk(n.Key)
+		w.walk(n.Value)
+
+	case *ast.ChanType:
+		w.walk(n.Value)
+
+	case *ast.DeclStmt:
+		w.walk(n.Decl)
+
+	case *ast.LabeledStmt:
+		w.walk(n.Label)
+		w.walk(n.Stmt)
+
+	case *ast.ExprStmt:
+		w.walk(n.X)
+
+	case *ast.SendStmt:
+		w.walk(n.Chan)
+		w.walk(n.Value)
+
+	case *ast.IncDecStmt:
+		w.walk(n.X)
+
+	case *ast.AssignStmt:
+		w.walkExprList(n.Lhs)
+		w.walkExprList(n.Rhs)
+
+	case *ast.GoStmt:
+		w.walk(n.Call)
+
+	case *ast.DeferStmt:
+		w.walk(n.Call)
+
+	case *ast.ReturnStmt:
+		w.walkExprList(n.Results)
+
+	case *ast.BranchStmt:
+		if n.Label != nil {
+			w.walk(n.Label)
+		}
+
+	case *ast.BlockStmt:
+		w.walkStmtList(n.List)
+
+	case *ast.IfStmt:
+		if n.Init != nil {
+			w.walk(n.Init)
+		}
+		w.walk(n.Cond)
+		deadcode := w.filterParams.deadcode
+		if !deadcode {
+			cv := w.filterParams.ctx.Types.Types[n.Cond].Value
+			if cv != nil {
+				w.filterParams.deadcode = !deadcode && !constant.BoolVal(cv)
+				w.walk(n.Body)
+				w.filterParams.deadcode = !w.filterParams.deadcode
+				if n.Else != nil {
+					w.walk(n.Else)
+				}
+				w.filterParams.deadcode = deadcode
+				return
+			}
+		}
+		w.walk(n.Body)
+		if n.Else != nil {
+			w.walk(n.Else)
+		}
+
+	case *ast.CaseClause:
+		w.walkExprList(n.List)
+		w.walkStmtList(n.Body)
+
+	case *ast.SwitchStmt:
+		if n.Init != nil {
+			w.walk(n.Init)
+		}
+		if n.Tag != nil {
+			w.walk(n.Tag)
+		}
+		w.walk(n.Body)
+
+	case *ast.TypeSwitchStmt:
+		if n.Init != nil {
+			w.walk(n.Init)
+		}
+		w.walk(n.Assign)
+		w.walk(n.Body)
+
+	case *ast.CommClause:
+		if n.Comm != nil {
+			w.walk(n.Comm)
+		}
+		w.walkStmtList(n.Body)
+
+	case *ast.SelectStmt:
+		w.walk(n.Body)
+
+	case *ast.ForStmt:
+		if n.Init != nil {
+			w.walk(n.Init)
+		}
+		if n.Cond != nil {
+			w.walk(n.Cond)
+		}
+		if n.Post != nil {
+			w.walk(n.Post)
+		}
+		w.walk(n.Body)
+
+	case *ast.RangeStmt:
+		if n.Key != nil {
+			w.walk(n.Key)
+		}
+		if n.Value != nil {
+			w.walk(n.Value)
+		}
+		w.walk(n.X)
+		w.walk(n.Body)
+
+	case *ast.ImportSpec:
+		if n.Name != nil {
+			w.walk(n.Name)
+		}
+		w.walk(n.Path)
+		if n.Comment != nil {
+			w.walk(n.Comment)
+		}
+
+	case *ast.ValueSpec:
+		if n.Doc != nil {
+			w.walk(n.Doc)
+		}
+		w.walkIdentList(n.Names)
+		if n.Type != nil {
+			w.walk(n.Type)
+		}
+		w.walkExprList(n.Values)
+		if n.Comment != nil {
+			w.walk(n.Comment)
+		}
+
+	case *ast.TypeSpec:
+		if n.Doc != nil {
+			w.walk(n.Doc)
+		}
+		w.walk(n.Name)
+		w.walk(n.Type)
+		if n.Comment != nil {
+			w.walk(n.Comment)
+		}
+
+	case *ast.GenDecl:
+		if n.Doc != nil {
+			w.walk(n.Doc)
+		}
+		for _, s := range n.Specs {
+			w.walk(s)
+		}
+
+	case *ast.FuncDecl:
+		if n.Doc != nil {
+			w.walk(n.Doc)
+		}
+		if n.Recv != nil {
+			w.walk(n.Recv)
+		}
+		w.walk(n.Name)
+		w.walk(n.Type)
+		if n.Body != nil {
+			w.walk(n.Body)
+		}
+
+	case *ast.File:
+		w.walk(n.Name)
+		w.walkDeclList(n.Decls)
+	}
+}

--- a/ruleguard/debug_test.go
+++ b/ruleguard/debug_test.go
@@ -24,6 +24,15 @@ func TestDebug(t *testing.T) {
 			},
 		},
 
+		`m.Match("f()").Where(!m.Deadcode())`: {
+			`f()`:             nil,
+			`if true { f() }`: nil,
+
+			`if false { f() }`: {
+				`input.go:4: [rules.go:5] rejected by !m.Deadcode()`,
+			},
+		},
+
 		`m.Match("f($x)").Where(m["x"].Type.Is("string"))`: {
 			`f("abc")`: nil,
 

--- a/ruleguard/filters.go
+++ b/ruleguard/filters.go
@@ -57,6 +57,15 @@ func makeOrFilter(lhs, rhs matchFilter) filterFunc {
 	}
 }
 
+func makeDeadcodeFilter(src string) filterFunc {
+	return func(params *filterParams) matchFilterResult {
+		if params.deadcode {
+			return filterSuccess
+		}
+		return filterFailure(src)
+	}
+}
+
 func makeFileImportsFilter(src, pkgPath string) filterFunc {
 	return func(params *filterParams) matchFilterResult {
 		_, imported := params.imports[pkgPath]

--- a/ruleguard/gorule.go
+++ b/ruleguard/gorule.go
@@ -65,6 +65,8 @@ type filterParams struct {
 
 	nodeText func(n ast.Node) []byte
 
+	deadcode bool
+
 	// varname is set only for custom filters before bytecode function is called.
 	varname string
 }

--- a/ruleguard/ir/filter_op.gen.go
+++ b/ruleguard/ir/filter_op.gen.go
@@ -96,52 +96,55 @@ const (
 	// $Value type: string
 	FilterVarTextMatchesOp FilterOp = 25
 
+	// m.Deadcode()
+	FilterDeadcodeOp FilterOp = 26
+
 	// m.GoVersion().Eq($Value)
 	// $Value type: string
-	FilterGoVersionEqOp FilterOp = 26
+	FilterGoVersionEqOp FilterOp = 27
 
 	// m.GoVersion().LessThan($Value)
 	// $Value type: string
-	FilterGoVersionLessThanOp FilterOp = 27
+	FilterGoVersionLessThanOp FilterOp = 28
 
 	// m.GoVersion().GreaterThan($Value)
 	// $Value type: string
-	FilterGoVersionGreaterThanOp FilterOp = 28
+	FilterGoVersionGreaterThanOp FilterOp = 29
 
 	// m.GoVersion().LessEqThan($Value)
 	// $Value type: string
-	FilterGoVersionLessEqThanOp FilterOp = 29
+	FilterGoVersionLessEqThanOp FilterOp = 30
 
 	// m.GoVersion().GreaterEqThan($Value)
 	// $Value type: string
-	FilterGoVersionGreaterEqThanOp FilterOp = 30
+	FilterGoVersionGreaterEqThanOp FilterOp = 31
 
 	// m.File.Imports($Value)
 	// $Value type: string
-	FilterFileImportsOp FilterOp = 31
+	FilterFileImportsOp FilterOp = 32
 
 	// m.File.PkgPath.Matches($Value)
 	// $Value type: string
-	FilterFilePkgPathMatchesOp FilterOp = 32
+	FilterFilePkgPathMatchesOp FilterOp = 33
 
 	// m.File.Name.Matches($Value)
 	// $Value type: string
-	FilterFileNameMatchesOp FilterOp = 33
+	FilterFileNameMatchesOp FilterOp = 34
 
 	// $Value holds a function name
 	// $Value type: string
-	FilterFilterFuncRefOp FilterOp = 34
+	FilterFilterFuncRefOp FilterOp = 35
 
 	// $Value holds a string constant
 	// $Value type: string
-	FilterStringOp FilterOp = 35
+	FilterStringOp FilterOp = 36
 
 	// $Value holds an int64 constant
 	// $Value type: int64
-	FilterIntOp FilterOp = 36
+	FilterIntOp FilterOp = 37
 
 	// m[`$$`].Node.Parent().Is($Args[0])
-	FilterRootNodeParentIsOp FilterOp = 37
+	FilterRootNodeParentIsOp FilterOp = 38
 )
 
 var filterOpNames = map[FilterOp]string{
@@ -171,6 +174,7 @@ var filterOpNames = map[FilterOp]string{
 	FilterVarTypeAssignableToOp:    `VarTypeAssignableTo`,
 	FilterVarTypeImplementsOp:      `VarTypeImplements`,
 	FilterVarTextMatchesOp:         `VarTextMatches`,
+	FilterDeadcodeOp:               `Deadcode`,
 	FilterGoVersionEqOp:            `GoVersionEq`,
 	FilterGoVersionLessThanOp:      `GoVersionLessThan`,
 	FilterGoVersionGreaterThanOp:   `GoVersionGreaterThan`,

--- a/ruleguard/ir/gen_filter_op.go
+++ b/ruleguard/ir/gen_filter_op.go
@@ -56,6 +56,8 @@ func main() {
 		{name: "VarTypeImplements", comment: "m[$Value].Type.Implements($Args[0])", valueType: "string"},
 		{name: "VarTextMatches", comment: "m[$Value].Text.Matches($Args[0])", valueType: "string"},
 
+		{name: "Deadcode", comment: "m.Deadcode()"},
+
 		{name: "GoVersionEq", comment: "m.GoVersion().Eq($Value)", valueType: "string"},
 		{name: "GoVersionLessThan", comment: "m.GoVersion().LessThan($Value)", valueType: "string"},
 		{name: "GoVersionGreaterThan", comment: "m.GoVersion().GreaterThan($Value)", valueType: "string"},

--- a/ruleguard/ir_loader.go
+++ b/ruleguard/ir_loader.go
@@ -518,6 +518,9 @@ func (l *irLoader) newFilter(filter ir.FilterExpr) (matchFilter, error) {
 	case ir.FilterFileImportsOp:
 		result.fn = makeFileImportsFilter(result.src, filter.Value.(string))
 
+	case ir.FilterDeadcodeOp:
+		result.fn = makeDeadcodeFilter(result.src)
+
 	case ir.FilterGoVersionEqOp:
 		version, err := ParseGoVersion(filter.Value.(string))
 		if err != nil {

--- a/ruleguard/irconv/irconv.go
+++ b/ruleguard/irconv/irconv.go
@@ -482,6 +482,8 @@ func (conv *converter) convertFilterExprImpl(e ast.Expr) ir.FilterExpr {
 	case *ast.CallExpr:
 		op := conv.inspectFilterSelector(e)
 		switch op.path {
+		case "Deadcode":
+			return ir.FilterExpr{Op: ir.FilterDeadcodeOp}
 		case "GoVersion.Eq":
 			return ir.FilterExpr{Op: ir.FilterGoVersionEqOp, Value: conv.parseStringArg(e.Args[0])}
 		case "GoVersion.LessThan":

--- a/ruleguard/perf_test.go
+++ b/ruleguard/perf_test.go
@@ -1,0 +1,541 @@
+package ruleguard
+
+import (
+	"go/ast"
+	"go/importer"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func BenchmarkEngineRun(b *testing.B) {
+	e := benchNewEngine(b)
+	ctx, f := benchRunContext(b, benchTargetCode)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := e.Run(ctx, f); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func benchRunContext(b *testing.B, src string) (*RunContext, *ast.File) {
+	b.Helper()
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "bench.go", src, parser.ParseComments)
+	if err != nil {
+		b.Fatalf("parse Go file: %v", err)
+	}
+
+	imp := importer.ForCompiler(fset, "source", nil)
+	typechecker := types.Config{Importer: imp}
+	typesInfo := &types.Info{
+		Types: map[ast.Expr]types.TypeAndValue{},
+		Uses:  map[*ast.Ident]types.Object{},
+		Defs:  map[*ast.Ident]types.Object{},
+	}
+	pkg, err := typechecker.Check("bench", fset, []*ast.File{f}, typesInfo)
+	if err != nil {
+		b.Fatalf("typecheck: %v", err)
+	}
+
+	ctx := &RunContext{
+		Pkg:   pkg,
+		Types: typesInfo,
+		Sizes: types.SizesFor("gc", runtime.GOARCH),
+		Fset:  fset,
+		Report: func(info GoRuleInfo, n ast.Node, msg string, s *Suggestion) {
+			// Do nothing.
+		},
+	}
+
+	return ctx, f
+}
+
+func benchNewEngine(b *testing.B) *Engine {
+	b.Helper()
+
+	src := `
+	package gorules
+	
+	import "github.com/quasilyte/go-ruleguard/dsl"
+
+	func sloppyLen(m dsl.Matcher) {
+		m.Match("len($_) >= 0").Report("$$ is always true")
+		m.Match("len($_) < 0").Report("$$ is always false")
+		m.Match("len($x) <= 0").Report("$$ can be len($x) == 0")
+	}
+
+	func dupSubExpr(m dsl.Matcher) {
+		m.Match("$x || $x",
+		"$x && $x",
+		"$x | $x",
+		"$x & $x",
+		"$x ^ $x",
+		"$x < $x",
+		"$x > $x",
+		"$x &^ $x",
+		"$x % $s",
+		"$x == $x",
+		"$x != $x",
+		"$x <= $x",
+		"$x >= $x",
+		"$x / $x",
+		"$x - $x").
+		Where(m["x"].Pure).
+		Report("suspicious identical LHS and RHS")
+	}
+
+	func appendCombine(m dsl.Matcher) {
+		m.Match("$dst = append($x, $a); $dst = append($x, $b)").
+		Report("$dst=append($x,$a,$b) is faster")
+	}
+
+	func localVarDecl(m dsl.Matcher) {
+		m.Match("var $x = $y").
+			Where(!m["$$"].Node.Parent().Is("File")).
+			Suggest("$x := $y").
+			Report("use := for local variables declaration")
+	
+		m.Match("var $x $_ = $y").
+			Where(!m["$$"].Node.Parent().Is("File")).
+			Report("use := for local variables declaration")
+	}
+	`
+
+	e := NewEngine()
+	ctx := &LoadContext{
+		Fset: token.NewFileSet(),
+	}
+	err := e.Load(ctx, "rules.go", strings.NewReader(src))
+	if err != nil {
+		b.Fatalf("load error: %v", err)
+	}
+	return e
+}
+
+const benchTargetCode = `// Source: https://learnxinyminutes.com/docs/go/
+
+// Single line comment
+/* Multi-
+line comment */
+
+/* A build tag is a line comment starting with // +build
+and can be executed by go build -tags="foo bar" command.
+Build tags are placed before the package clause near or at the top of the file
+followed by a blank line or other line comments. */
+// +build prod, dev, test
+
+// A package clause starts every source file.
+// Main is a special name declaring an executable rather than a library.
+package main
+
+// Import declaration declares library packages referenced in this file.
+import (
+	"fmt"       // A package in the Go standard library.
+	"io/ioutil" // Implements some I/O utility functions.
+	m "math"    // Math library with local alias m.
+	"net/http"  // Yes, a web server!
+	"os"        // OS functions like working with the file system
+	"strconv"   // String conversions.
+)
+
+// A function definition. Main is special. It is the entry point for the
+// executable program. Love it or hate it, Go uses brace brackets.
+func main() {
+	// Println outputs a line to stdout.
+	// It comes from the package fmt.
+	fmt.Println("Hello world!")
+
+	// Call another function within this package.
+	beyondHello()
+}
+
+// Functions have parameters in parentheses.
+// If there are no parameters, empty parentheses are still required.
+func beyondHello() {
+	var x int // Variable declaration. Variables must be declared before use.
+	x = 3     // Variable assignment.
+	// "Short" declarations use := to infer the type, declare, and assign.
+	y := 4
+	sum, prod := learnMultiple(x, y)        // Function returns two values.
+	fmt.Println("sum:", sum, "prod:", prod) // Simple output.
+	learnTypes()                            // < y minutes, learn more!
+}
+
+func learnMultiple(x, y int) (sum, prod int) {
+	return x + y, x * y // Return two values.
+}
+
+// Some built-in types and literals.
+func learnTypes() {
+	// Short declaration usually gives you what you want.
+	str := "Learn Go!" // string type.
+
+	s2 := "ok"
+
+	// Non-ASCII literal. Go source is UTF-8.
+	g := 'Σ' // rune type, an alias for int32, holds a unicode code point.
+
+	f := 3.14195 // float64, an IEEE-754 64-bit floating point number.
+	c := 3 + 4i  // complex128, represented internally with two float64's.
+
+	// var syntax with initializers.
+	var u uint = 7 // Unsigned, but implementation dependent size as with int.
+	var pi float32 = 22. / 7
+
+	// Conversion syntax with a short declaration.
+	n := byte('\n') // byte is an alias for uint8.
+
+	// Arrays have size fixed at compile time.
+	var a4 [4]int                    // An array of 4 ints, initialized to all 0.
+	a5 := [...]int{3, 1, 5, 10, 100} // An array initialized with a fixed size of five
+	// elements, with values 3, 1, 5, 10, and 100.
+
+	// Arrays have value semantics.
+	a4_cpy := a4                    // a4_cpy is a copy of a4, two separate instances.
+	a4_cpy[0] = 25                  // Only a4_cpy is changed, a4 stays the same.
+	fmt.Println(a4_cpy[0] == a4[0]) // false
+
+	// Slices have dynamic size. Arrays and slices each have advantages
+	// but use cases for slices are much more common.
+	s3 := []int{4, 5, 9}    // Compare to a5. No ellipsis here.
+	s4 := make([]int, 4)    // Allocates slice of 4 ints, initialized to all 0.
+	var d2 [][]float64      // Declaration only, nothing allocated here.
+	bs := []byte("a slice") // Type conversion syntax.
+
+	// Slices (as well as maps and channels) have reference semantics.
+	s3_cpy := s3                    // Both variables point to the same instance.
+	s3_cpy[0] = 0                   // Which means both are updated.
+	fmt.Println(s3_cpy[0] == s3[0]) // true
+
+	// Because they are dynamic, slices can be appended to on-demand.
+	// To append elements to a slice, the built-in append() function is used.
+	// First argument is a slice to which we are appending. Commonly,
+	// the array variable is updated in place, as in example below.
+	s := []int{1, 2, 3}    // Result is a slice of length 3.
+	s = append(s, 4, 5, 6) // Added 3 elements. Slice now has length of 6.
+	fmt.Println(s)         // Updated slice is now [1 2 3 4 5 6]
+
+	// To append another slice, instead of list of atomic elements we can
+	// pass a reference to a slice or a slice literal like this, with a
+	// trailing ellipsis, meaning take a slice and unpack its elements,
+	// appending them to slice s.
+	s = append(s, []int{7, 8, 9}...) // Second argument is a slice literal.
+	fmt.Println(s)                   // Updated slice is now [1 2 3 4 5 6 7 8 9]
+
+	p, q := learnMemory() // Declares p, q to be type pointer to int.
+	fmt.Println(*p, *q)   // * follows a pointer. This prints two ints.
+
+	// Maps are a dynamically growable associative array type, like the
+	// hash or dictionary types of some other languages.
+	m := map[string]int{"three": 3, "four": 4}
+	m["one"] = 1
+
+	// Unused variables are an error in Go.
+	// The underscore lets you "use" a variable but discard its value.
+	_, _, _, _, _, _, _, _, _, _ = str, s2, g, f, u, pi, n, a5, s4, bs
+	// Usually you use it to ignore one of the return values of a function
+	// For example, in a quick and dirty script you might ignore the
+	// error value returned from os.Create, and expect that the file
+	// will always be created.
+	file, _ := os.Create("output.txt")
+	fmt.Fprint(file, "This is how you write to a file, by the way")
+	file.Close()
+
+	// Output of course counts as using a variable.
+	fmt.Println(s, c, a4, s3, d2, m)
+
+	learnFlowControl() // Back in the flow.
+}
+
+// It is possible, unlike in many other languages for functions in go
+// to have named return values.
+// Assigning a name to the type being returned in the function declaration line
+// allows us to easily return from multiple points in a function as well as to
+// only use the return keyword, without anything further.
+func learnNamedReturns(x, y int) (z int) {
+	z = x * y
+	return // z is implicit here, because we named it earlier.
+}
+
+// Go is fully garbage collected. It has pointers but no pointer arithmetic.
+// You can make a mistake with a nil pointer, but not by incrementing a pointer.
+// Unlike in C/Cpp taking and returning an address of a local varible is also safe.
+func learnMemory() (p, q *int) {
+	// Named return values p and q have type pointer to int.
+	p = new(int) // Built-in function new allocates memory.
+	// The allocated int slice is initialized to 0, p is no longer nil.
+	s := make([]int, 20) // Allocate 20 ints as a single block of memory.
+	s[3] = 7             // Assign one of them.
+	r := -2              // Declare another local variable.
+	return &s[3], &r     // & takes the address of an object.
+}
+
+func expensiveComputation() float64 {
+	return m.Exp(10)
+}
+
+func learnFlowControl() {
+	// If statements require brace brackets, and do not require parentheses.
+	if true {
+		fmt.Println("told ya")
+	}
+	// Formatting is standardized by the command line command "go fmt".
+	if false {
+		// Pout.
+	} else {
+		// Gloat.
+	}
+	// Use switch in preference to chained if statements.
+	x := 42.0
+	switch x { // want "floating point as switch expression"
+	case 0:
+	case 1, 2: // Can have multiple matches on one case
+	case 42:
+		// Cases don't "fall through".
+		/*
+			There is a "fallthrough" keyword however, see:
+			  https://github.com/golang/go/wiki/Switch#fall-through
+		*/
+	case 43:
+		// Unreached.
+	default:
+		// Default case is optional.
+	}
+
+	// Type switch allows switching on the type of something instead of value
+	var data interface{}
+	data = ""
+	switch c := data.(type) {
+	case string:
+		fmt.Println(c, "is a string")
+	case int64:
+		fmt.Printf("%d is an int64\n", c)
+	default:
+		// all other cases
+	}
+
+	// Like if, for doesn't use parens either.
+	// Variables declared in for and if are local to their scope.
+	for x := 0; x < 3; x++ { // ++ is a statement.
+		fmt.Println("iteration", x)
+	}
+	// x == 42 here.
+
+	// For is the only loop statement in Go, but it has alternate forms.
+	for { // Infinite loop.
+		break    // Just kidding.
+		continue // Unreached.
+	}
+
+	// You can use range to iterate over an array, a slice, a string, a map, or a channel.
+	// range returns one (channel) or two values (array, slice, string and map).
+	for key, value := range map[string]int{"one": 1, "two": 2, "three": 3} {
+		// for each pair in the map, print key and value
+		fmt.Printf("key=%s, value=%d\n", key, value)
+	}
+	// If you only need the value, use the underscore as the key
+	for _, name := range []string{"Bob", "Bill", "Joe"} {
+		fmt.Printf("Hello, %s\n", name)
+	}
+
+	// As with for, := in an if statement means to declare and assign
+	// y first, then test y > x.
+	if y := expensiveComputation(); y > x {
+		x = y
+	}
+	// Function literals are closures.
+	xBig := func() bool {
+		return x > 10000 // References x declared above switch statement.
+	}
+	x = 99999
+	fmt.Println("xBig:", xBig()) // true
+	x = 1.3e3                    // This makes x == 1300
+	fmt.Println("xBig:", xBig()) // false now.
+
+	// What's more is function literals may be defined and called inline,
+	// acting as an argument to function, as long as:
+	// a) function literal is called immediately (),
+	// b) result type matches expected type of argument.
+	fmt.Println("Add + double two numbers: ",
+		func(a, b int) int {
+			return (a + b) * 2
+		}(10, 2)) // Called with args 10 and 2
+	// => Add + double two numbers: 24
+
+	// When you need it, you'll love it.
+	goto love
+love:
+
+	learnFunctionFactory() // func returning func is fun(3)(3)
+	learnDefer()      // A quick detour to an important keyword.
+	learnInterfaces() // Good stuff coming up!
+}
+
+func learnFunctionFactory() {
+	// Next two are equivalent, with second being more practical
+	fmt.Println(sentenceFactory("summer")("A beautiful", "day!"))
+
+	d := sentenceFactory("summer")
+	fmt.Println(d("A beautiful", "day!"))
+	fmt.Println(d("A lazy", "afternoon!"))
+}
+
+// Decorators are common in other languages. Same can be done in Go
+// with function literals that accept arguments.
+func sentenceFactory(mystring string) func(before, after string) string {
+	return func(before, after string) string {
+		return fmt.Sprintf("%s %s %s", before, mystring, after) // new string
+	}
+}
+
+func learnDefer() (ok bool) {
+	// A defer statement pushes a function call onto a list. The list of saved
+	// calls is executed AFTER the surrounding function returns.
+	defer fmt.Println("deferred statements execute in reverse (LIFO) order.")
+	defer fmt.Println("\nThis line is being printed first because")
+	// Defer is commonly used to close a file, so the function closing the
+	// file stays close to the function opening the file.
+	return true
+}
+
+// Define Stringer as an interface type with one method, String.
+type Stringer interface {
+	String() string
+}
+
+// Define pair as a struct with two fields, ints named x and y.
+type pair struct {
+	x, y int
+}
+
+// Define a method on type pair. Pair now implements Stringer because Pair has defined all the methods in the interface.
+func (p pair) String() string { // p is called the "receiver"
+	// Sprintf is another public function in package fmt.
+	// Dot syntax references fields of p.
+	return fmt.Sprintf("(%d, %d)", p.x, p.y)
+}
+
+func learnInterfaces() {
+	// Brace syntax is a "struct literal". It evaluates to an initialized
+	// struct. The := syntax declares and initializes p to this struct.
+	p := pair{3, 4}
+	fmt.Println(p.String()) // Call String method of p, of type pair.
+	var i Stringer          // Declare i of interface type Stringer.
+	i = p                   // Valid because pair implements Stringer
+	// Call String method of i, of type Stringer. Output same as above.
+	fmt.Println(i.String())
+
+	// Functions in the fmt package call the String method to ask an object
+	// for a printable representation of itself.
+	fmt.Println(p) // Output same as above. Println calls String method.
+	fmt.Println(i) // Output same as above.
+
+	learnVariadicParams("great", "learning", "here!")
+}
+
+// Functions can have variadic parameters.
+func learnVariadicParams(myStrings ...interface{}) {
+	// Iterate each value of the variadic.
+	// The underbar here is ignoring the index argument of the array.
+	for _, param := range myStrings {
+		fmt.Println("param:", param)
+	}
+
+	// Pass variadic value as a variadic parameter.
+	fmt.Println("params:", fmt.Sprintln(myStrings...))
+
+	learnErrorHandling()
+}
+
+func learnErrorHandling() {
+	// ", ok" idiom used to tell if something worked or not.
+	m := map[int]string{3: "three", 4: "four"}
+	if x, ok := m[1]; !ok { // ok will be false because 1 is not in the map.
+		fmt.Println("no one there")
+	} else {
+		fmt.Print(x) // x would be the value, if it were in the map.
+	}
+	// An error value communicates not just "ok" but more about the problem.
+	if _, err := strconv.Atoi("non-int"); err != nil { // _ discards value
+		// prints 'strconv.ParseInt: parsing "non-int": invalid syntax'
+		fmt.Println(err)
+	}
+	// We'll revisit interfaces a little later. Meanwhile,
+	learnConcurrency()
+}
+
+// c is a channel, a concurrency-safe communication object.
+func inc(i int, c chan int) {
+	c <- i + 1 // <- is the "send" operator when a channel appears on the left.
+}
+
+// We'll use inc to increment some numbers concurrently.
+func learnConcurrency() {
+	// Same make function used earlier to make a slice. Make allocates and
+	// initializes slices, maps, and channels.
+	c := make(chan int)
+	// Start three concurrent goroutines. Numbers will be incremented
+	// concurrently, perhaps in parallel if the machine is capable and
+	// properly configured. All three send to the same channel.
+	go inc(0, c) // go is a statement that starts a new goroutine.
+	go inc(10, c)
+	go inc(-805, c)
+	// Read three results from the channel and print them out.
+	// There is no telling in what order the results will arrive!
+	fmt.Println(<-c, <-c, <-c) // channel on right, <- is "receive" operator.
+
+	cs := make(chan string)       // Another channel, this one handles strings.
+	ccs := make(chan chan string) // A channel of string channels.
+	go func() { c <- 84 }()       // Start a new goroutine just to send a value.
+	go func() { cs <- "wordy" }() // Again, for cs this time.
+	// Select has syntax like a switch statement but each case involves
+	// a channel operation. It selects a case at random out of the cases
+	// that are ready to communicate.
+	select {
+	case i := <-c: // The value received can be assigned to a variable,
+		fmt.Printf("it's a %T", i)
+	case <-cs: // or the value received can be discarded.
+		fmt.Println("it's a string")
+	case <-ccs: // Empty channel, not ready for communication.
+		fmt.Println("didn't happen.")
+	}
+	// At this point a value was taken from either c or cs. One of the two
+	// goroutines started above has completed, the other will remain blocked.
+
+	learnWebProgramming() // Go does it. You want to do it too.
+}
+
+// A single function from package http starts a web server.
+func learnWebProgramming() {
+
+	// First parameter of ListenAndServe is TCP address to listen to.
+	// Second parameter is an interface, specifically http.Handler.
+	go func() {
+		err := http.ListenAndServe(":8080", pair{})
+		fmt.Println(err) // don't ignore errors
+	}()
+
+	requestServer()
+}
+
+// Make pair an http.Handler by implementing its only method, ServeHTTP.
+func (p pair) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Serve data with a method of http.ResponseWriter.
+	w.Write([]byte("You learned Go in Y minutes!"))
+}
+
+func requestServer() {
+	resp, err := http.Get("http://localhost:8080")
+	fmt.Println(err)
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	fmt.Printf("\nWebserver said: %s", string(body))
+}
+`

--- a/ruleguard/runner.go
+++ b/ruleguard/runner.go
@@ -121,14 +121,11 @@ func (rr *rulesRunner) run(f *ast.File) error {
 	rr.collectImports(f)
 
 	if rr.rules.universal.categorizedNum != 0 {
-		ast.Inspect(f, func(n ast.Node) bool {
-			if n == nil {
-				rr.nodePath.Pop()
-				return false
-			}
-			rr.nodePath.Push(n)
+		var inspector astWalker
+		inspector.nodePath = &rr.nodePath
+		inspector.filterParams = &rr.filterParams
+		inspector.Walk(f, func(n ast.Node) {
 			rr.runRules(n)
-			return true
 		})
 	}
 


### PR DESCRIPTION
Required for diagnostics like "go vet shift" (analysis/passes/shift).

To implement that feature without performance sacrifices,
our own implementation of `ast.Inspect` is rolled.
That code is actually a little faster than the original one.

```
    name         old time/op  new time/op  delta
    EngineRun-8  82.6µs ± 1%  68.2µs ± 1%  -17.45%
```