### PR TITLE
internal/gogrep: fix `if $x {...}` compilation

### DIFF
--- a/analyzer/testdata/src/gocritic/f1.go
+++ b/analyzer/testdata/src/gocritic/f1.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"regexp"
 	"strings"
+	"sync"
 )
 
 func selfAssign(x int, ys []string) {
@@ -488,4 +489,58 @@ func (exampleStruct) Sprintf() string {
 func _(w io.Writer) {
 	var fmt exampleStruct
 	w.Write([]byte(fmt.Sprintf()))
+}
+
+func sink(args ...interface{}) {}
+
+func _(cond bool, m, m2 *sync.Map) {
+	{
+		actual, ok := m.Load("key") // want `\Quse m.LoadAndDelete to perform load+delete operations atomically`
+		if ok {
+			m.Delete("key")
+			sink(actual)
+		}
+	}
+
+	{
+		// Condition mismatched.
+		v, ok := m.Load("key")
+		if ok && cond {
+			m.Delete("key")
+			sink(v)
+		}
+	}
+
+	{
+		// Maps mismatched.
+		actual, ok := m.Load("key")
+		if ok {
+			m2.Delete("key")
+			sink(actual)
+		}
+	}
+
+	{
+		// Keys mismatched.
+		actual, ok := m.Load("key")
+		if ok {
+			m.Delete("key2")
+			sink(actual)
+		}
+	}
+
+	{
+		// Return values are ignored.
+		m.Load("key")
+		if cond {
+			m.Delete("key2")
+		}
+	}
+
+	{
+		v, deleted := m.LoadAndDelete("key")
+		if deleted {
+			sink(v)
+		}
+	}
 }

--- a/analyzer/testdata/src/gocritic/rules.go
+++ b/analyzer/testdata/src/gocritic/rules.go
@@ -179,3 +179,10 @@ func preferFprint(m dsl.Matcher) {
 		Suggest("fmt.Fprintln($w, $args)").
 		Report(`fmt.Fprintln($w, $args) should be preferred to the $$`)
 }
+
+func syncMapLoadAndDelete(m dsl.Matcher) {
+	m.Match(`$_, $ok := $m.Load($k); if $ok { $m.Delete($k); $*_ }`).
+		Where(m.GoVersion().GreaterEqThan("1.15") &&
+			m["m"].Type.Is(`*sync.Map`)).
+		Report(`use $m.LoadAndDelete to perform load+delete operations atomically`)
+}

--- a/internal/gogrep/compile.go
+++ b/internal/gogrep/compile.go
@@ -716,15 +716,17 @@ func (c *compiler) compileIfStmt(n *ast.IfStmt) {
 			return
 		}
 		// Named $* is harder and slower.
-		c.prog.insts = append(c.prog.insts, instruction{
-			op:         pickOp(n.Else == nil, opIfNamedOptStmt, opIfNamedOptElseStmt),
-			valueIndex: c.internString(ident, info.Name),
-		})
-		c.compileStmt(n.Body)
-		if n.Else != nil {
-			c.compileStmt(n.Else)
+		if info.Seq {
+			c.prog.insts = append(c.prog.insts, instruction{
+				op:         pickOp(n.Else == nil, opIfNamedOptStmt, opIfNamedOptElseStmt),
+				valueIndex: c.internString(ident, info.Name),
+			})
+			c.compileStmt(n.Body)
+			if n.Else != nil {
+				c.compileStmt(n.Else)
+			}
+			return
 		}
-		return
 	}
 
 	switch {

--- a/internal/gogrep/match_test.go
+++ b/internal/gogrep/match_test.go
@@ -394,6 +394,8 @@ func TestMatch(t *testing.T) {
 		{`if $*_ {} else {}`, 1, `if a(); b {} else {}`},
 		{`if $*_ {} else {}`, 1, `if a() {} else {}`},
 		{`if a(); $*_ {}`, 0, `if b {}`},
+		{`if $_ { $*_ }`, 1, `if cond {}`},
+		{`if $_ { $*_ }`, 1, `if cond { f() }`},
 
 		// Switch stmt.
 		{`switch {}`, 1, `switch {}`},
@@ -615,6 +617,12 @@ func TestMatch(t *testing.T) {
 		{`var $v $_; if $cond { $_ }`, 1, `{ var x int; if true { x = 10 } }`},
 		{`var $v $_; if $cond { $v = $x }`, 1, `{ var x int; if true { x = 10 } }`},
 		{`var $v $_; if $cond { $v = $x } else { $v = $y }`, 1, `{ var x int; if true { x = 10 } else { x = 20 } }`},
+		{`f(); if $ok { $*_; }`, 1, `{ f(); if ok {} }`},
+		{`$_, $ok := $m.Load($k); if $ok {}`, 1, `{ v, ok := m.Load(k); if ok {} }`},
+		{`$_, $ok := $m.Load($k); if $ok { $*_ }`, 1, `{ v, ok := m.Load(k); if ok {} }`},
+		{`$_, $ok := $m.Load($k); if $ok { $*_ }`, 1, `{ v, ok := m.Load(k); if ok { f() } }`},
+		{`$_, $ok := $m.Load($k); if $ok { $*_ }`, 0, `{ v, ok1 := m.Load(k); if ok2 { f() } }`},
+		{`$_, $ok := $m.Load($k); if $ok { $*_ }`, 0, `{ v, ok := m.Load(k) }`},
 
 		// Expr list (+ partial matches).
 		{`b, c`, 1, `[]int{a, b, c, d}`},

--- a/ruleguard/filters.go
+++ b/ruleguard/filters.go
@@ -251,6 +251,9 @@ func makeLineFilter(src, varname string, op token.Token, rhsVarname string) filt
 
 func makeGoVersionFilter(src string, op token.Token, version GoVersion) filterFunc {
 	return func(params *filterParams) matchFilterResult {
+		if params.ctx.GoVersion.IsAny() {
+			return filterSuccess
+		}
 		if versionCompare(params.ctx.GoVersion, op, version) {
 			return filterSuccess
 		}

--- a/ruleguard/go_version.go
+++ b/ruleguard/go_version.go
@@ -12,6 +12,8 @@ type GoVersion struct {
 	Minor int
 }
 
+func (ver GoVersion) IsAny() bool { return ver.Major == 0 }
+
 func ParseGoVersion(version string) (GoVersion, error) {
 	var result GoVersion
 	if version == "" {


### PR DESCRIPTION
Don't emit `ifOpt` for `if $x`; that operation is intended for `if $*x` patterns.