### PR TITLE
ruleguard: associate rule line with a pattern string

### DIFF
--- a/analyzer/testdata/src/gocritic/f1.go
+++ b/analyzer/testdata/src/gocritic/f1.go
@@ -681,3 +681,55 @@ func argOderProperArgsOrder(s string, b []byte) {
 	const configFileName = "foo.json"
 	_ = strings.TrimSuffix(configFileName, filepath.Ext(configFileName))
 }
+
+func equalFold(s1, s2 string, b1, b2 []byte) {
+	_ = strings.ToLower(s1) == s2                  // want `\Qconsider replacing with strings.EqualFold(s1, s2)`
+	_ = s1 == strings.ToLower(s2)                  // want `\Qconsider replacing with strings.EqualFold(s1, s2)`
+	_ = strings.ToLower(s1) == strings.ToLower(s2) // want `\Qconsider replacing with strings.EqualFold(s1, s2)`
+	_ = strings.ToLower(s1) == "select"            // want `\Qconsider replacing with strings.EqualFold(s1, "select")`
+	_ = "select" == strings.ToLower(s1)            // want `\Qconsider replacing with strings.EqualFold("select", s1)`
+	_ = strings.ToUpper(s1) == s2                  // want `\Qconsider replacing with strings.EqualFold(s1, s2)`
+	_ = s1 == strings.ToUpper(s2)                  // want `\Qconsider replacing with strings.EqualFold(s1, s2)`
+	_ = strings.ToUpper(s1) == strings.ToUpper(s2) // want `\Qconsider replacing with strings.EqualFold(s1, s2)`
+
+	_ = strings.ToLower(s1) != s2                  // want `\Qconsider replacing with !strings.EqualFold(s1, s2)`
+	_ = s1 != strings.ToLower(s2)                  // want `\Qconsider replacing with !strings.EqualFold(s1, s2)`
+	_ = strings.ToLower(s1) != strings.ToLower(s2) // want `\Qconsider replacing with !strings.EqualFold(s1, s2)`
+	_ = strings.ToLower(s1) != "select"            // want `\Qconsider replacing with !strings.EqualFold(s1, "select")`
+	_ = "select" != strings.ToLower(s1)            // want `\Qconsider replacing with !strings.EqualFold("select", s1)`
+	_ = strings.ToUpper(s1) != s2                  // want `\Qconsider replacing with !strings.EqualFold(s1, s2)`
+	_ = s1 != strings.ToUpper(s2)                  // want `\Qconsider replacing with !strings.EqualFold(s1, s2)`
+	_ = strings.ToUpper(s1) != strings.ToUpper(s2) // want `\Qconsider replacing with !strings.EqualFold(s1, s2)`
+
+	_ = bytes.Equal(bytes.ToLower(b1), b2)                // want `\Qconsider replacing with bytes.EqualFold(b1, b2)`
+	_ = bytes.Equal(b1, bytes.ToLower(b2))                // want `\Qconsider replacing with bytes.EqualFold(b1, b2)`
+	_ = bytes.Equal(bytes.ToLower(b1), bytes.ToLower(b2)) // want `\Qconsider replacing with bytes.EqualFold(b1, b2)`
+	_ = bytes.Equal(bytes.ToLower(b1), []byte("select"))  // want `\Qconsider replacing with bytes.EqualFold(b1, []byte("select"))`
+	_ = bytes.Equal([]byte("select"), bytes.ToLower(b1))  // want `\Qconsider replacing with bytes.EqualFold([]byte("select"), b1)`
+	_ = bytes.Equal(bytes.ToUpper(b1), b2)                // want `\Qconsider replacing with bytes.EqualFold(b1, b2)`
+	_ = bytes.Equal(b1, bytes.ToUpper(b2))                // want `\Qconsider replacing with bytes.EqualFold(b1, b2)`
+	_ = bytes.Equal(bytes.ToUpper(b1), bytes.ToUpper(b2)) // want `\Qconsider replacing with bytes.EqualFold(b1, b2)`
+
+	_ = !bytes.Equal(bytes.ToLower(b1), b2)                // want `\Qconsider replacing with bytes.EqualFold(b1, b2)`
+	_ = !bytes.Equal(b1, bytes.ToLower(b2))                // want `\Qconsider replacing with bytes.EqualFold(b1, b2)`
+	_ = !bytes.Equal(bytes.ToLower(b1), bytes.ToLower(b2)) // want `\Qconsider replacing with bytes.EqualFold(b1, b2)`
+	_ = !bytes.Equal(bytes.ToLower(b1), []byte("select"))  // want `\Qconsider replacing with bytes.EqualFold(b1, []byte("select"))`
+	_ = !bytes.Equal([]byte("select"), bytes.ToLower(b1))  // want `\Qconsider replacing with bytes.EqualFold([]byte("select"), b1)`
+	_ = !bytes.Equal(bytes.ToUpper(b1), b2)                // want `\Qconsider replacing with bytes.EqualFold(b1, b2)`
+	_ = !bytes.Equal(b1, bytes.ToUpper(b2))                // want `\Qconsider replacing with bytes.EqualFold(b1, b2)`
+	_ = !bytes.Equal(bytes.ToUpper(b1), bytes.ToUpper(b2)) // want `\Qconsider replacing with bytes.EqualFold(b1, b2)`
+
+	_ = strings.ToLower(s1) == strings.ToLower(strings.ToUpper(s2))
+	_ = strings.ToUpper(s1) == strings.ToLower(s2)
+	_ = strings.ToUpper(s1) == strings.ToUpper(s1)
+	_ = strings.ToLower(s1) != strings.ToLower(strings.ToUpper(s2))
+	_ = strings.ToUpper(s1) != strings.ToLower(s2)
+	_ = strings.ToUpper(s1) != strings.ToUpper(s1)
+
+	_ = bytes.Equal(bytes.ToLower(b1), bytes.ToLower(bytes.ToUpper(b2)))
+	_ = bytes.Equal(bytes.ToUpper(b1), bytes.ToLower(b2))
+	_ = bytes.Equal(bytes.ToUpper(b1), bytes.ToUpper(b1))
+	_ = !bytes.Equal(bytes.ToLower(b1), bytes.ToLower(bytes.ToUpper(b2)))
+	_ = !bytes.Equal(bytes.ToUpper(b1), bytes.ToLower(b2))
+	_ = !bytes.Equal(bytes.ToUpper(b1), bytes.ToUpper(b1))
+}


### PR DESCRIPTION
In a multi-pattern rule, it's more useful to give a source line
of a respective pattern.

Consider this example:

         //line1: m.Match(
         //line2:        `foo()`,
         //line3:        `bar()`,
         //line4: )

Previously, if either `foo()` or `bar()` would match, we would
have a matchInfo rule line set to `line1`, since it's a
rule definition line (`Match` expression location).

Now we'll have a rule line set to `line1` if `foo()` matches,
otherwise `line2` if `bar()` matches. This is useful during
both debugging and rules usage.