### PR TITLE
add troubleshooting info to panic message when ast.Node parse error occurs

### DIFF
--- a/internal/gogrep/parse.go
+++ b/internal/gogrep/parse.go
@@ -129,6 +129,11 @@ func parseType(fset *token.FileSet, src string) (ast.Expr, *ast.File, error) {
 // It also returns the *ast.File used for the parsing, so that the returned node
 // can be easily type-checked.
 func parseDetectingNode(fset *token.FileSet, src string) (ast.Node, *ast.File, error) {
+	defer func() {
+		if p := recover(); p != nil {
+			panic(fmt.Sprintf("Failed to parse ast.Node: %s. Source: %s", p, src))
+		}
+	}()
 	file := fset.AddFile("", fset.Base(), len(src))
 	scan := scanner.Scanner{}
 	scan.Init(file, []byte(src), nil, 0)


### PR DESCRIPTION
When trying to upgrade go-critic to 0.5.8, a panic occurs with the following stack trace. The panic message does not include any information about the ast.Node being parsed. It would help to print the source. This does not actually fix the underlying issue, merely to make the panic message less obscure.

https://github.com/golangci/golangci-lint/pull/2041

```
ERRO [runner] Panic: gocritic: package "goutil" (isInitialPkg: true, needAnalyzeSource: true): invalid base 168394943 (should be >= 168395006): goroutine 26385 [running]:
runtime/debug.Stack()
	/usr/local/go/src/runtime/debug/stack.go:24 +0x65
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe.func1()
	/home/serosset/goroot/src/github.com/golangci-lint/pkg/golinters/goanalysis/runner_action.go:101 +0x155
panic({0x125f080, 0xc004e65be0})
	/usr/local/go/src/runtime/panic.go:1038 +0x215
go/token.(*FileSet).AddFile(0xc000284100, {0x0, 0x0}, 0xa0980bf, 0x61)
	/usr/local/go/src/go/token/position.go:434 +0x374
github.com/quasilyte/go-ruleguard/internal/gogrep.parseDetectingNode(0x146ccc1, {0xc003112bd0, 0x61})
	/home/serosset/goroot/pkg/mod/github.com/quasilyte/go-ruleguard@v0.3.9/internal/gogrep/parse.go:132 +0x65
github.com/quasilyte/go-ruleguard/internal/gogrep.parseExpr(0xc0038a91c0, {0x146ccc1, 0x114})
	/home/serosset/goroot/pkg/mod/github.com/quasilyte/go-ruleguard@v0.3.9/internal/gogrep/parse.go:49 +0x55
github.com/quasilyte/go-ruleguard/internal/gogrep.Compile(0x7fc5d0085058, {0x146ccc1, 0x0}, 0x74)
	/home/serosset/goroot/pkg/mod/github.com/quasilyte/go-ruleguard@v0.3.9/internal/gogrep/gogrep.go:59 +0x2f
github.com/quasilyte/go-ruleguard/ruleguard.(*irLoader).loadSyntaxRule(_, {0xc00b227290, 0x17f, 0x0, {0x1476311, 0x33}, {0x13bd1c5, 0x1}, {0x0, 0x0}, ...}, ...)
	/home/serosset/goroot/pkg/mod/github.com/quasilyte/go-ruleguard@v0.3.9/ruleguard/ir_loader.go:300 +0x76
github.com/quasilyte/go-ruleguard/ruleguard.(*irLoader).loadRule(0x0, {0x17f, {0x146ccc1, 0x2a}, {0x0, 0x0}, {0x1476311, 0x33}, {0x0, 0x0}, ...})
	/home/serosset/goroot/pkg/mod/github.com/quasilyte/go-ruleguard@v0.3.9/ruleguard/ir_loader.go:276 +0x1f8
github.com/quasilyte/go-ruleguard/ruleguard.(*irLoader).loadRuleGroup(0xc0038a9848, 0x1ead0a0)
	/home/serosset/goroot/pkg/mod/github.com/quasilyte/go-ruleguard@v0.3.9/ruleguard/ir_loader.go:250 +0x4b8
github.com/quasilyte/go-ruleguard/ruleguard.(*irLoader).LoadFile(0xc0038a9848, {0x1434848, 0xe}, 0x1e964c0)
	/home/serosset/goroot/pkg/mod/github.com/quasilyte/go-ruleguard@v0.3.9/ruleguard/ir_loader.go:92 +0x1d4
github.com/quasilyte/go-ruleguard/ruleguard.(*engine).LoadFromIR(0xc004e65b50, 0xc018f105d0, {0x1434848, 0xe}, 0xc00dd7a000)
	/home/serosset/goroot/pkg/mod/github.com/quasilyte/go-ruleguard@v0.3.9/ruleguard/engine.go:96 +0x1f6
github.com/quasilyte/go-ruleguard/ruleguard.(*Engine).LoadFromIR(...)
	/home/serosset/goroot/pkg/mod/github.com/quasilyte/go-ruleguard@v0.3.9/ruleguard/ruleguard.go:44
github.com/go-critic/go-critic/checkers.init.10.func1(0xc001c7ae08)
	/home/serosset/goroot/pkg/mod/github.com/go-critic/go-critic@v0.5.8/checkers/checkers.go:74 +0x154
github.com/go-critic/go-critic/framework/linter.addChecker.func2(0xc01aea4d20)
	/home/serosset/goroot/pkg/mod/github.com/go-critic/go-critic@v0.5.8/framework/linter/checkers_db.go:79 +0x118
github.com/go-critic/go-critic/framework/linter.newChecker(0xc00b2b6e10, 0xc00b2b6e10)
	/home/serosset/goroot/pkg/mod/github.com/go-critic/go-critic@v0.5.8/framework/linter/checkers_db.go:92 +0x51
github.com/go-critic/go-critic/framework/linter.NewChecker(...)
	/home/serosset/goroot/pkg/mod/github.com/go-critic/go-critic@v0.5.8/framework/linter/lintpack.go:169
github.com/golangci/golangci-lint/pkg/golinters.buildEnabledCheckers(0x12ca2e0, 0xc014f7a2a0)
	/home/serosset/goroot/src/github.com/golangci-lint/pkg/golinters/gocritic.go:148 +0x145
github.com/golangci/golangci-lint/pkg/golinters.NewGocritic.func1.1(0xc0114a7380)
	/home/serosset/goroot/src/github.com/golangci-lint/pkg/golinters/gocritic.go:45 +0x125
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyze(0xc0028eb790)
	/home/serosset/goroot/src/github.com/golangci-lint/pkg/golinters/goanalysis/runner_action.go:187 +0x9c4
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe.func2()
	/home/serosset/goroot/src/github.com/golangci-lint/pkg/golinters/goanalysis/runner_action.go:105 +0x1d
github.com/golangci/golangci-lint/pkg/timeutils.(*Stopwatch).TrackStage(0xc001560280, {0x13d46c6, 0x8}, 0xc003270760)
	/home/serosset/goroot/src/github.com/golangci-lint/pkg/timeutils/stopwatch.go:111 +0x4a
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe(0xc0028eb790)
	/home/serosset/goroot/src/github.com/golangci-lint/pkg/golinters/goanalysis/runner_action.go:104 +0x85
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze.func2(0x1e)
	/home/serosset/goroot/src/github.com/golangci-lint/pkg/golinters/goanalysis/runner_loadingpackage.go:80 +0x67
created by github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze
	/home/serosset/goroot/src/github.com/golangci-lint/pkg/golinters/goanalysis/runner_loadingpackage.go:75 +0x1fd 
WARN [runner] Can't run linter goanalysis_metalinter: goanalysis_metalinter: gocritic: package "goutil" (isInitialPkg: true, needAnalyzeSource: true): invalid base 168394943 (should be >= 168395006) 

```