### PR TITLE
[GH-issue: 273] - use `||` in `go-ruleguard/analyzer/testdata/src/gocritic/rules.go`

### DIFF
--- a/analyzer/testdata/src/gocritic/rules.go
+++ b/analyzer/testdata/src/gocritic/rules.go
@@ -79,13 +79,8 @@ func testRules(m dsl.Matcher) {
 		Where(m["arr"].Type.Is(`*[$_]$_`)).
 		Report(`explicit array deref is redundant`)
 
-	// Can factor into a single rule when || operator
-	// is supported in filters.
 	m.Match(`$s[:]`).
-		Where(m["s"].Type.Is(`string`)).
-		Report(`can simplify $$ to $s`)
-	m.Match(`$s[:]`).
-		Where(m["s"].Type.Is(`[]$_`)).
+		Where(m["s"].Type.Is(`string`) || m["s"].Type.Is(`[]$_`)).
 		Report(`can simplify $$ to $s`)
 
 	m.Match(`switch $_ {case $_: $*_}`,


### PR DESCRIPTION
Fixes - #273 

Summary - Use `||` in `Where()` to replace 2-`Match()` rule with a single `Match()` rule