### PR TITLE
Add testing for const iota rules

### DIFF
--- a/analyzer/testdata/src/regression/issue291.go
+++ b/analyzer/testdata/src/regression/issue291.go
@@ -1,0 +1,25 @@
+package regression
+
+type explicitIntType int
+
+const (
+	ZeroExplicit explicitIntType = iota // want `\Qavoid use of iota for constant types`
+	OneExplicit
+	TwoExplicit
+)
+
+type implicitIntType int
+
+const (
+	ZeroImplicit = iota // want `\Qavoid use of iota for constant types`
+	OneImplicit
+	TwoImplicit
+)
+
+type noIotaIntType int
+
+const (
+	ZeroNoIota = 0
+	OneNoIota  = 1
+	TwoNoIota  = 2
+)

--- a/analyzer/testdata/src/regression/rules.go
+++ b/analyzer/testdata/src/regression/rules.go
@@ -33,3 +33,10 @@ func issue192(m dsl.Matcher) {
 	m.Match(`fmt.Println(fmt.Sprintf($format, $*args, $last))`).
 		Suggest(`fmt.Printf($format+"\n", $args, $last)`)
 }
+
+func issue291(m dsl.Matcher) {
+	m.Match(`$_ $_ = $iota`, `const ( $_ = $iota; $*_ )`).
+		Where(m["iota"].Text == "iota").
+		At(m["iota"]).
+		Report("avoid use of iota for constant types")
+}


### PR DESCRIPTION
Related to https://github.com/quasilyte/go-ruleguard/issues/291

@quasilyte You were correct, HEAD appears to properly cover this use case. Test case is included here. Hopefully I included the code in the correct location.

By the way, I really admire your project. I'm using it for custom lint rules in golang to enforce good coding practices. Thank you for your efforts.

Cheers.
-Tim