### PR TITLE
ruleguard: add profiling labels support

### DIFF
--- a/ruleguard/profiling/no_labels.go
+++ b/ruleguard/profiling/no_labels.go
@@ -1,0 +1,16 @@
+//go:build !pproflabels
+// +build !pproflabels
+
+package profiling
+
+import (
+	"context"
+)
+
+const LabelsEnabled = false
+
+func EnterWithLabels(origContext context.Context, name string) {
+}
+
+func Leave(origContext context.Context) {
+}

--- a/ruleguard/profiling/with_labels.go
+++ b/ruleguard/profiling/with_labels.go
@@ -1,0 +1,21 @@
+//go:build pproflabels
+// +build pproflabels
+
+package profiling
+
+import (
+	"context"
+	"runtime/pprof"
+)
+
+const LabelsEnabled = true
+
+func EnterWithLabels(origContext context.Context, name string) {
+	labels := pprof.Labels("rules", name)
+	ctx := pprof.WithLabels(origContext, labels)
+	pprof.SetGoroutineLabels(ctx)
+}
+
+func Leave(origContext context.Context) {
+	pprof.SetGoroutineLabels(origContext)
+}


### PR DESCRIPTION
When ruleguard is compiled with `--tags pproflabels`, profiling
will record per rules group labels, like `rules:groupname`.

This makes it easies to find the rules that may need to be
optimized or re-written in some other way.

Build tags protection is used to avoid the overhead in
the normal mode, when labels are not needed.

```
(pprof) tags
 rules: Total 2.3s
        410.0ms (18.14%): dupArg
        350.0ms (15.49%): offBy1
        250.0ms (11.06%): badLock
        160.0ms ( 7.08%): argOrder
        140.0ms ( 6.19%): equalFold
        120.0ms ( 5.31%): redundantSprint
        110.0ms ( 4.87%): wrapperFunc
         90.0ms ( 3.98%): ioutilDeprecated
         80.0ms ( 3.54%): preferFprint
         70.0ms ( 3.10%): assignOp
         60.0ms ( 2.65%): badCall
         60.0ms ( 2.65%): externalErrorReassign
         60.0ms ( 2.65%): stringXbytes
         50.0ms ( 2.21%): valSwap
         40.0ms ( 1.77%): stringConcatSimplify
         40.0ms ( 1.77%): yodaStyleExpr
         20.0ms ( 0.88%): badSorting
         20.0ms ( 0.88%): flagDeref
         20.0ms ( 0.88%): httpNoBody
         20.0ms ( 0.88%): preferStringWriter
         20.0ms ( 0.88%): timeExprSimplify
         10.0ms ( 0.44%): dynamicFmtString
         10.0ms ( 0.44%): emptyStringTest
         10.0ms ( 0.44%): preferWriteByte
         10.0ms ( 0.44%): regexpMust
         10.0ms ( 0.44%): returnAfterHttpError
         10.0ms ( 0.44%): sloppyLen
         10.0ms ( 0.44%): sprintfQuotedString
```