### PR TITLE
ruleguard: continue pattern matching for multi-match patterns

### DIFF
--- a/analyzer/testdata/src/regression/issue115.go
+++ b/analyzer/testdata/src/regression/issue115.go
@@ -4,10 +4,10 @@ func testIssue115() {
 	intFunc := func() int { return 19 }
 	stringFunc := func() string { return "19" }
 
-	println(13)
-	println(43 + 5)
+	println(13, "!constexpr int")
+	println(43+5, "!constexpr int")
 
-	println("foo")        // want `\Q"foo" is not a constexpr int`
-	println(intFunc())    // want `\QintFunc() is not a constexpr int`
-	println(stringFunc()) // want `\QstringFunc() is not a constexpr int`
+	println("foo", "!constexpr int")        // want `\Q"foo" is not a constexpr int`
+	println(intFunc(), "!constexpr int")    // want `\QintFunc() is not a constexpr int`
+	println(stringFunc(), "!constexpr int") // want `\QstringFunc() is not a constexpr int`
 }

--- a/analyzer/testdata/src/regression/issue339.go
+++ b/analyzer/testdata/src/regression/issue339.go
@@ -1,0 +1,22 @@
+package regression
+
+func _() {
+	println("339") // want `\Qpattern1`
+	println("x")   // want `\Qpattern2`
+
+	println("339") // want `\Qpattern1`
+
+	println("x")
+}
+
+func _() {
+	println("x")   // want `\Qpattern2`
+	println("339") // want `\Qpattern1`
+
+	println("x")   // want `\Qpattern2`
+	println("339") // want `\Qpattern1`
+
+	println("x")
+	println("x") // want `\Qpattern2`
+	println("339")
+}

--- a/analyzer/testdata/src/regression/rules.go
+++ b/analyzer/testdata/src/regression/rules.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package gorules
@@ -21,7 +22,7 @@ func issue72(m dsl.Matcher) {
 }
 
 func issue115(m dsl.Matcher) {
-	m.Match(`println($x)`).
+	m.Match(`println($x, "!constexpr int")`).
 		Where(!(m["x"].Const && m["x"].Type.Is("int"))).
 		Report("$x is not a constexpr int")
 }
@@ -44,4 +45,9 @@ func issue291(m dsl.Matcher) {
 		Where(m["iota"].Text == "iota").
 		At(m["iota"]).
 		Report("good, have explicit type")
+}
+
+func issue339(m dsl.Matcher) {
+	m.Match(`println("339"); println("x")`).Report("pattern1")
+	m.Match(`println("x"); println("339")`).Report("pattern2")
 }

--- a/ruleguard/runner.go
+++ b/ruleguard/runner.go
@@ -233,7 +233,7 @@ func (rr *rulesRunner) runRules(n ast.Node) {
 			profiling.Leave(rr.bgContext)
 		}
 
-		if matched {
+		if matched && !multiMatchTags[tag] {
 			break
 		}
 	}
@@ -413,4 +413,11 @@ func truncateText(s string, maxLen int) string {
 	left := s[:leftLen]
 	right := s[len(s)-rightLen:]
 	return left + placeholder + right
+}
+
+var multiMatchTags = [nodetag.NumBuckets]bool{
+	nodetag.BlockStmt:  true,
+	nodetag.CaseClause: true,
+	nodetag.CommClause: true,
+	nodetag.File:       true,
 }


### PR DESCRIPTION
This is probably a temporary and sub-optimal solution, but
it should do for now.

Since matches are much more rare than pattern misses,
we do the check under the `matched` condition.
Extra condition shouldn't make anything measurably slower there.

Fixes #339