### PR TITLE
ruleguard: call Walk handler with nodetag

### DIFF
--- a/ruleguard/ast_walker.go
+++ b/ruleguard/ast_walker.go
@@ -3,6 +3,8 @@ package ruleguard
 import (
 	"go/ast"
 	"go/constant"
+
+	"github.com/quasilyte/gogrep/nodetag"
 )
 
 type astWalker struct {
@@ -10,10 +12,10 @@ type astWalker struct {
 
 	filterParams *filterParams
 
-	visit func(ast.Node)
+	visit func(ast.Node, nodetag.Value)
 }
 
-func (w *astWalker) Walk(root ast.Node, visit func(ast.Node)) {
+func (w *astWalker) Walk(root ast.Node, visit func(ast.Node, nodetag.Value)) {
 	w.visit = visit
 	w.walk(root)
 }
@@ -46,8 +48,6 @@ func (w *astWalker) walk(n ast.Node) {
 	w.nodePath.Push(n)
 	defer w.nodePath.Pop()
 
-	w.visit(n)
-
 	switch n := n.(type) {
 	case *ast.Field:
 		// TODO: handle field types.
@@ -61,32 +61,39 @@ func (w *astWalker) walk(n ast.Node) {
 		}
 
 	case *ast.Ellipsis:
+		w.visit(n, nodetag.Ellipsis)
 		if n.Elt != nil {
 			w.walk(n.Elt)
 		}
 
 	case *ast.FuncLit:
+		w.visit(n, nodetag.FuncLit)
 		w.walk(n.Type)
 		w.walk(n.Body)
 
 	case *ast.CompositeLit:
+		w.visit(n, nodetag.CompositeLit)
 		if n.Type != nil {
 			w.walk(n.Type)
 		}
 		w.walkExprList(n.Elts)
 
 	case *ast.ParenExpr:
+		w.visit(n, nodetag.ParenExpr)
 		w.walk(n.X)
 
 	case *ast.SelectorExpr:
+		w.visit(n, nodetag.SelectorExpr)
 		w.walk(n.X)
 		w.walk(n.Sel)
 
 	case *ast.IndexExpr:
+		w.visit(n, nodetag.IndexExpr)
 		w.walk(n.X)
 		w.walk(n.Index)
 
 	case *ast.SliceExpr:
+		w.visit(n, nodetag.SliceExpr)
 		w.walk(n.X)
 		if n.Low != nil {
 			w.walk(n.Low)
@@ -99,39 +106,48 @@ func (w *astWalker) walk(n ast.Node) {
 		}
 
 	case *ast.TypeAssertExpr:
+		w.visit(n, nodetag.TypeAssertExpr)
 		w.walk(n.X)
 		if n.Type != nil {
 			w.walk(n.Type)
 		}
 
 	case *ast.CallExpr:
+		w.visit(n, nodetag.CallExpr)
 		w.walk(n.Fun)
 		w.walkExprList(n.Args)
 
 	case *ast.StarExpr:
+		w.visit(n, nodetag.StarExpr)
 		w.walk(n.X)
 
 	case *ast.UnaryExpr:
+		w.visit(n, nodetag.UnaryExpr)
 		w.walk(n.X)
 
 	case *ast.BinaryExpr:
+		w.visit(n, nodetag.BinaryExpr)
 		w.walk(n.X)
 		w.walk(n.Y)
 
 	case *ast.KeyValueExpr:
+		w.visit(n, nodetag.KeyValueExpr)
 		w.walk(n.Key)
 		w.walk(n.Value)
 
 	case *ast.ArrayType:
+		w.visit(n, nodetag.ArrayType)
 		if n.Len != nil {
 			w.walk(n.Len)
 		}
 		w.walk(n.Elt)
 
 	case *ast.StructType:
+		w.visit(n, nodetag.StructType)
 		w.walk(n.Fields)
 
 	case *ast.FuncType:
+		w.visit(n, nodetag.FuncType)
 		if n.Params != nil {
 			w.walk(n.Params)
 		}
@@ -140,54 +156,69 @@ func (w *astWalker) walk(n ast.Node) {
 		}
 
 	case *ast.InterfaceType:
+		w.visit(n, nodetag.InterfaceType)
 		w.walk(n.Methods)
 
 	case *ast.MapType:
+		w.visit(n, nodetag.MapType)
 		w.walk(n.Key)
 		w.walk(n.Value)
 
 	case *ast.ChanType:
+		w.visit(n, nodetag.ChanType)
 		w.walk(n.Value)
 
 	case *ast.DeclStmt:
+		w.visit(n, nodetag.DeclStmt)
 		w.walk(n.Decl)
 
 	case *ast.LabeledStmt:
+		w.visit(n, nodetag.LabeledStmt)
 		w.walk(n.Label)
 		w.walk(n.Stmt)
 
 	case *ast.ExprStmt:
+		w.visit(n, nodetag.ExprStmt)
 		w.walk(n.X)
 
 	case *ast.SendStmt:
+		w.visit(n, nodetag.SendStmt)
 		w.walk(n.Chan)
 		w.walk(n.Value)
 
 	case *ast.IncDecStmt:
+		w.visit(n, nodetag.IncDecStmt)
 		w.walk(n.X)
 
 	case *ast.AssignStmt:
+		w.visit(n, nodetag.AssignStmt)
 		w.walkExprList(n.Lhs)
 		w.walkExprList(n.Rhs)
 
 	case *ast.GoStmt:
+		w.visit(n, nodetag.GoStmt)
 		w.walk(n.Call)
 
 	case *ast.DeferStmt:
+		w.visit(n, nodetag.DeferStmt)
 		w.walk(n.Call)
 
 	case *ast.ReturnStmt:
+		w.visit(n, nodetag.ReturnStmt)
 		w.walkExprList(n.Results)
 
 	case *ast.BranchStmt:
+		w.visit(n, nodetag.BranchStmt)
 		if n.Label != nil {
 			w.walk(n.Label)
 		}
 
 	case *ast.BlockStmt:
+		w.visit(n, nodetag.BlockStmt)
 		w.walkStmtList(n.List)
 
 	case *ast.IfStmt:
+		w.visit(n, nodetag.IfStmt)
 		if n.Init != nil {
 			w.walk(n.Init)
 		}
@@ -212,10 +243,12 @@ func (w *astWalker) walk(n ast.Node) {
 		}
 
 	case *ast.CaseClause:
+		w.visit(n, nodetag.CaseClause)
 		w.walkExprList(n.List)
 		w.walkStmtList(n.Body)
 
 	case *ast.SwitchStmt:
+		w.visit(n, nodetag.SwitchStmt)
 		if n.Init != nil {
 			w.walk(n.Init)
 		}
@@ -225,6 +258,7 @@ func (w *astWalker) walk(n ast.Node) {
 		w.walk(n.Body)
 
 	case *ast.TypeSwitchStmt:
+		w.visit(n, nodetag.TypeSwitchStmt)
 		if n.Init != nil {
 			w.walk(n.Init)
 		}
@@ -232,15 +266,18 @@ func (w *astWalker) walk(n ast.Node) {
 		w.walk(n.Body)
 
 	case *ast.CommClause:
+		w.visit(n, nodetag.CommClause)
 		if n.Comm != nil {
 			w.walk(n.Comm)
 		}
 		w.walkStmtList(n.Body)
 
 	case *ast.SelectStmt:
+		w.visit(n, nodetag.SelectStmt)
 		w.walk(n.Body)
 
 	case *ast.ForStmt:
+		w.visit(n, nodetag.ForStmt)
 		if n.Init != nil {
 			w.walk(n.Init)
 		}
@@ -253,6 +290,7 @@ func (w *astWalker) walk(n ast.Node) {
 		w.walk(n.Body)
 
 	case *ast.RangeStmt:
+		w.visit(n, nodetag.RangeStmt)
 		if n.Key != nil {
 			w.walk(n.Key)
 		}
@@ -263,6 +301,7 @@ func (w *astWalker) walk(n ast.Node) {
 		w.walk(n.Body)
 
 	case *ast.ImportSpec:
+		w.visit(n, nodetag.ImportSpec)
 		if n.Name != nil {
 			w.walk(n.Name)
 		}
@@ -272,6 +311,7 @@ func (w *astWalker) walk(n ast.Node) {
 		}
 
 	case *ast.ValueSpec:
+		w.visit(n, nodetag.ValueSpec)
 		if n.Doc != nil {
 			w.walk(n.Doc)
 		}
@@ -285,6 +325,7 @@ func (w *astWalker) walk(n ast.Node) {
 		}
 
 	case *ast.TypeSpec:
+		w.visit(n, nodetag.TypeSpec)
 		if n.Doc != nil {
 			w.walk(n.Doc)
 		}
@@ -295,6 +336,7 @@ func (w *astWalker) walk(n ast.Node) {
 		}
 
 	case *ast.GenDecl:
+		w.visit(n, nodetag.GenDecl)
 		if n.Doc != nil {
 			w.walk(n.Doc)
 		}
@@ -303,6 +345,7 @@ func (w *astWalker) walk(n ast.Node) {
 		}
 
 	case *ast.FuncDecl:
+		w.visit(n, nodetag.FuncDecl)
 		prevFunc := w.filterParams.currentFunc
 		w.filterParams.currentFunc = n
 		if n.Doc != nil {
@@ -319,6 +362,7 @@ func (w *astWalker) walk(n ast.Node) {
 		w.filterParams.currentFunc = prevFunc
 
 	case *ast.File:
+		w.visit(n, nodetag.File)
 		w.walk(n.Name)
 		w.walkDeclList(n.Decls)
 	}

--- a/ruleguard/runner.go
+++ b/ruleguard/runner.go
@@ -138,8 +138,8 @@ func (rr *rulesRunner) run(f *ast.File) error {
 		var inspector astWalker
 		inspector.nodePath = &rr.nodePath
 		inspector.filterParams = &rr.filterParams
-		inspector.Walk(f, func(n ast.Node) {
-			rr.runRules(n)
+		inspector.Walk(f, func(n ast.Node, tag nodetag.Value) {
+			rr.runRules(n, tag)
 		})
 	}
 
@@ -213,12 +213,11 @@ func (rr *rulesRunner) runCommentRules(comment *ast.Comment) {
 	}
 }
 
-func (rr *rulesRunner) runRules(n ast.Node) {
+func (rr *rulesRunner) runRules(n ast.Node, tag nodetag.Value) {
 	// profiling.LabelsEnabled is constant, so labels-related
 	// code should be a no-op inside normal build.
 	// To enable labels, use "-tags pproflabels" build tag.
 
-	tag := nodetag.FromNode(n)
 	for _, rule := range rr.rules.universal.rulesByTag[tag] {
 		if profiling.LabelsEnabled {
 			profiling.EnterWithLabels(rr.bgContext, rule.group.Name)


### PR DESCRIPTION
This allows us to get rid of `nodetag.FromNode()` call per
every ast node being processed.

	name         old time/op  new time/op  delta
	EngineRun-8  94.8µs ± 1%  82.8µs ± 0%  -12.70%  (p=0.000 n=10+8)