### PR TITLE
ruleguard: make truncate len configurable

### DIFF
--- a/ruleguard/ruleguard.go
+++ b/ruleguard/ruleguard.go
@@ -104,6 +104,17 @@ type RunContext struct {
 	Report func(*ReportData)
 
 	GoVersion GoVersion
+
+	// TruncateLen is a length threshold (in bytes) for interpolated vars in Report() templates.
+	//
+	// Truncation removes the part of the string in the middle and replaces it with <...>
+	// so it meets the max length constraint.
+	//
+	// The default value is 60 (implied if value is 0).
+	//
+	// Note that this value is ignored for Suggest templates.
+	// Ruleguard doesn't truncate suggested replacement candidates.
+	TruncateLen int
 }
 
 type ReportData struct {

--- a/ruleguard/runner.go
+++ b/ruleguard/runner.go
@@ -29,6 +29,8 @@ type rulesRunner struct {
 	ctx   *RunContext
 	rules *goRuleSet
 
+	truncateLen int
+
 	reportData ReportData
 
 	gogrepState gogrep.MatcherState
@@ -72,11 +74,15 @@ func newRulesRunner(ctx *RunContext, buildContext *build.Context, state *engineS
 		rules:       rules,
 		gogrepState: gogrepState,
 		nodePath:    newNodePath(),
+		truncateLen: ctx.TruncateLen,
 		filterParams: filterParams{
 			env:      state.env.GetEvalEnv(),
 			importer: importer,
 			ctx:      ctx,
 		},
+	}
+	if ctx.TruncateLen == 0 {
+		rr.truncateLen = 60
 	}
 	rr.filterParams.nodeText = rr.nodeText
 	rr.filterParams.nodePath = &rr.nodePath
@@ -425,7 +431,7 @@ func (rr *rulesRunner) renderMessage(msg string, m matchData, truncate bool) str
 			text := rr.nodeText(n)
 			text = rr.fixedText(text, n, msg[dollarPos+1+nameLen:])
 			if truncate {
-				text = truncateText(text, 60)
+				text = truncateText(text, rr.truncateLen)
 			}
 			result = append(result, text...)
 		} else {


### PR DESCRIPTION
go-perfguard would benefit from longer truncate len thresholds.
We keep 60 as a default, but provide a way to override that.