### PR TITLE
ruleguard/quasigo: pass args via ValueStack

### DIFF
--- a/ruleguard/filters.go
+++ b/ruleguard/filters.go
@@ -186,7 +186,7 @@ func makeCustomVarFilter(src, varname string, fn *quasigo.Func) filterFunc {
 		// We should probably catch the panic here, print trace and return "false"
 		// from the filter (or even propagate that panic to let it crash).
 		params.varname = varname
-		result := quasigo.Call(params.env, fn, params)
+		result := quasigo.Call(params.env, fn)
 		if result.Value().(bool) {
 			return filterSuccess
 		}

--- a/ruleguard/quasigo/compile_test.go
+++ b/ruleguard/quasigo/compile_test.go
@@ -25,7 +25,7 @@ func TestCompile(t *testing.T) {
 		},
 
 		`return b`: {
-			`  PushParam 2 # b`,
+			`  PushParam 1 # b`,
 			`  ReturnTop`,
 		},
 
@@ -55,7 +55,7 @@ func TestCompile(t *testing.T) {
 			`  EqInt`,
 			`  Dup`,
 			`  JumpFalse 8 # L0`,
-			`  PushParam 1 # s`,
+			`  PushParam 0 # s`,
 			`  PushConst 0 # value="foo"`,
 			`  EqString`,
 			`L0:`,
@@ -81,7 +81,7 @@ func TestCompile(t *testing.T) {
 		},
 
 		`if b { return 1 }; return 0`: {
-			`  PushParam 2 # b`,
+			`  PushParam 1 # b`,
 			`  JumpFalse 6 # L0`,
 			`  PushIntConst 0 # value=1`,
 			`  ReturnIntTop`,
@@ -91,7 +91,7 @@ func TestCompile(t *testing.T) {
 		},
 
 		`if b { return 1 } else { return 0 }`: {
-			`  PushParam 2 # b`,
+			`  PushParam 1 # b`,
 			`  JumpFalse 6 # L0`,
 			`  PushIntConst 0 # value=1`,
 			`  ReturnIntTop`,
@@ -103,7 +103,7 @@ func TestCompile(t *testing.T) {
 		`x := 0; if b { x = 5 } else { x = 50 }; return x`: {
 			`  PushIntConst 0 # value=0`,
 			`  SetIntLocal 0 # x`,
-			`  PushParam 2 # b`,
+			`  PushParam 1 # b`,
 			`  JumpFalse 10 # L0`,
 			`  PushIntConst 1 # value=5`,
 			`  SetIntLocal 0 # x`,
@@ -124,7 +124,7 @@ func TestCompile(t *testing.T) {
 			`  PushConst 0 # value="a"`,
 			`  ReturnTop`,
 			`L0:`,
-			`  PushParam 2 # b`,
+			`  PushParam 1 # b`,
 			`  JumpFalse 6 # L1`,
 			`  PushConst 1 # value="b"`,
 			`  ReturnTop`,
@@ -134,50 +134,50 @@ func TestCompile(t *testing.T) {
 		},
 
 		`return eface == nil`: {
-			`  PushParam 3 # eface`,
+			`  PushParam 2 # eface`,
 			`  IsNil`,
 			`  ReturnTop`,
 		},
 
 		`return nil == eface`: {
-			`  PushParam 3 # eface`,
+			`  PushParam 2 # eface`,
 			`  IsNil`,
 			`  ReturnTop`,
 		},
 
 		`return eface != nil`: {
-			`  PushParam 3 # eface`,
+			`  PushParam 2 # eface`,
 			`  IsNotNil`,
 			`  ReturnTop`,
 		},
 
 		`return nil != eface`: {
-			`  PushParam 3 # eface`,
+			`  PushParam 2 # eface`,
 			`  IsNotNil`,
 			`  ReturnTop`,
 		},
 
 		`return s[:]`: {
-			`  PushParam 1 # s`,
+			`  PushParam 0 # s`,
 			`  ReturnTop`,
 		},
 
 		`return s[1:]`: {
-			`  PushParam 1 # s`,
+			`  PushParam 0 # s`,
 			`  PushIntConst 0 # value=1`,
 			`  StringSliceFrom`,
 			`  ReturnTop`,
 		},
 
 		`return s[:1]`: {
-			`  PushParam 1 # s`,
+			`  PushParam 0 # s`,
 			`  PushIntConst 0 # value=1`,
 			`  StringSliceTo`,
 			`  ReturnTop`,
 		},
 
 		`return s[1:2]`: {
-			`  PushParam 1 # s`,
+			`  PushParam 0 # s`,
 			`  PushIntConst 0 # value=1`,
 			`  PushIntConst 1 # value=2`,
 			`  StringSlice`,
@@ -185,7 +185,7 @@ func TestCompile(t *testing.T) {
 		},
 
 		`return len(s) >= 0`: {
-			`  PushParam 1 # s`,
+			`  PushParam 0 # s`,
 			`  StringLen`,
 			`  PushIntConst 0 # value=0`,
 			`  GtEqInt`,

--- a/ruleguard/quasigo/debug_info.go
+++ b/ruleguard/quasigo/debug_info.go
@@ -5,8 +5,9 @@ type debugInfo struct {
 }
 
 type funcDebugInfo struct {
-	paramNames []string
-	localNames []string
+	paramNames    []string
+	intParamNames []string
+	localNames    []string
 }
 
 func newDebugInfo() *debugInfo {

--- a/ruleguard/quasigo/disasm.go
+++ b/ruleguard/quasigo/disasm.go
@@ -39,10 +39,14 @@ func disasm(env *Env, fn *Func) string {
 			id := decode16(code, pc+1)
 			arg = id
 			comment = env.nativeFuncs[id].name
-		case opPushParam, opPushIntParam:
+		case opPushParam:
 			index := int(code[pc+1])
 			arg = index
 			comment = dbg.paramNames[index]
+		case opPushIntParam:
+			index := int(code[pc+1])
+			arg = index
+			comment = dbg.intParamNames[index]
 		case opSetLocal, opSetIntLocal, opPushLocal, opPushIntLocal, opIncLocal, opDecLocal:
 			index := int(code[pc+1])
 			arg = index

--- a/ruleguard/quasigo/eval.go
+++ b/ruleguard/quasigo/eval.go
@@ -38,22 +38,22 @@ func (s *ValueStack) dup() { s.objects = append(s.objects, s.objects[len(s.objec
 // Identical to s.Pop() without using the result.
 func (s *ValueStack) discard() { s.objects = s.objects[:len(s.objects)-1] }
 
-func eval(env *EvalEnv, fn *Func, args []interface{}) CallResult {
+func eval(env *EvalEnv, fn *Func, top, intTop int) CallResult {
 	pc := 0
 	code := fn.code
-	stack := env.stack
+	stack := &env.Stack
 	var locals [maxFuncLocals]interface{}
 	var intLocals [maxFuncLocals]int
 
 	for {
 		switch op := opcode(code[pc]); op {
 		case opPushParam:
-			index := code[pc+1]
-			stack.Push(args[index])
+			index := int(code[pc+1])
+			stack.Push(stack.objects[top+index])
 			pc += 2
 		case opPushIntParam:
-			index := code[pc+1]
-			stack.PushInt(args[index].(int))
+			index := int(code[pc+1])
+			stack.PushInt(stack.ints[intTop+index])
 			pc += 2
 
 		case opPushLocal:

--- a/ruleguard/quasigo/quasigo.go
+++ b/ruleguard/quasigo/quasigo.go
@@ -34,7 +34,7 @@ type EvalEnv struct {
 	nativeFuncs []nativeFunc
 	userFuncs   []*Func
 
-	stack *ValueStack
+	Stack ValueStack
 }
 
 // NewEnv creates a new empty environment.
@@ -47,7 +47,7 @@ func (env *Env) GetEvalEnv() *EvalEnv {
 	return &EvalEnv{
 		nativeFuncs: env.nativeFuncs,
 		userFuncs:   env.userFuncs,
-		stack: &ValueStack{
+		Stack: ValueStack{
 			objects: make([]interface{}, 0, 32),
 			ints:    make([]int, 0, 16),
 		},
@@ -93,11 +93,19 @@ func Compile(ctx *CompileContext, fn *ast.FuncDecl) (compiled *Func, err error) 
 	return compile(ctx, fn)
 }
 
-// Call invokes a given function with provided arguments.
-func Call(env *EvalEnv, fn *Func, args ...interface{}) CallResult {
-	env.stack.objects = env.stack.objects[:0]
-	env.stack.ints = env.stack.ints[:0]
-	return eval(env, fn, args)
+// Call invokes a given function.
+// All arguments should be pushed to env.Stack prior to this call.
+//
+// Note that arguments are not popped off the stack,
+// so you can bind the args once and use Call multiple times.
+// If you want to reset arguments, do env.Stack.Reset().
+func Call(env *EvalEnv, fn *Func) CallResult {
+	numObjectArgs := len(env.Stack.objects)
+	numIntArgs := len(env.Stack.ints)
+	result := eval(env, fn, 0, 0)
+	env.Stack.objects = env.Stack.objects[:numObjectArgs]
+	env.Stack.ints = env.Stack.ints[:numIntArgs]
+	return result
 }
 
 // CallResult is a return value of Call function.
@@ -141,6 +149,12 @@ type ValueStack struct {
 	objects     []interface{}
 	ints        []int
 	variadicLen int
+}
+
+// Reset empties the stack.
+func (s *ValueStack) Reset() {
+	s.objects = s.objects[:0]
+	s.ints = s.ints[:0]
 }
 
 // Pop removes the top stack element and returns it.

--- a/ruleguard/runner.go
+++ b/ruleguard/runner.go
@@ -71,6 +71,7 @@ func newRulesRunner(ctx *RunContext, buildContext *build.Context, state *engineS
 	gogrepState.Types = ctx.Types
 	gogrepSubState := gogrep.NewMatcherState()
 	gogrepSubState.Types = ctx.Types
+	evalEnv := state.env.GetEvalEnv()
 	rr := &rulesRunner{
 		bgContext:      context.Background(),
 		ctx:            ctx,
@@ -82,11 +83,12 @@ func newRulesRunner(ctx *RunContext, buildContext *build.Context, state *engineS
 		truncateLen:    ctx.TruncateLen,
 		filterParams: filterParams{
 			typematchState: typematch.NewMatcherState(),
-			env:            state.env.GetEvalEnv(),
+			env:            evalEnv,
 			importer:       importer,
 			ctx:            ctx,
 		},
 	}
+	evalEnv.Stack.Push(&rr.filterParams)
 	if ctx.TruncateLen == 0 {
 		rr.truncateLen = 60
 	}


### PR DESCRIPTION
It makes it easier to implement quasigo funcs call
later on, so Go->quasigo and quasigo->quasigo can use
the same calling convention.

Note that args can be bound once (until env.Stack.Reset),
which is useful in plugins-like context when you pass
the same argument list to all user functions.