### PR TITLE
ruleguard: fix sizeof filter for type params

### DIFF
--- a/analyzer/testdata/src/generics/rules.go
+++ b/analyzer/testdata/src/generics/rules.go
@@ -10,3 +10,11 @@ func externalErrorReassign(m dsl.Matcher) {
 		Where(m["err"].Type.Is(`error`) && m["pkg"].Object.Is(`PkgName`)).
 		Report(`suspicious reassigment of error from another package`)
 }
+
+func largeLoopCopy(m dsl.Matcher) {
+	m.Match(
+		`for $_, $v := range $_ { $*_ }`,
+	).
+		Where(m["v"].Type.Size > 512).
+		Report(`loop copies large value each iteration`)
+}

--- a/analyzer/testdata/src/generics/target.go
+++ b/analyzer/testdata/src/generics/target.go
@@ -7,3 +7,11 @@ type myType[T any] struct {
 func (m *myType[T]) set(v T) {
 	m.value = v
 }
+
+func Map[T, R any](s []T, f func(T) R) []R {
+	result := make([]R, len(s))
+	for i, v := range s {
+		result[i] = f(v)
+	}
+	return result
+}

--- a/dsl/dsl.go
+++ b/dsl/dsl.go
@@ -222,6 +222,9 @@ func (SinkType) Is(typ string) bool { return boolResult }
 // ExprType describes a type of a matcher expr.
 type ExprType struct {
 	// Size represents expression type size in bytes.
+	//
+	// For expressions of unknown size, like type params in generics,
+	// any filter using this operand will fail.
 	Size int
 }
 

--- a/ruleguard/utils.go
+++ b/ruleguard/utils.go
@@ -9,6 +9,8 @@ import (
 	"regexp/syntax"
 	"strconv"
 	"strings"
+
+	"golang.org/x/exp/typeparams"
 )
 
 var invalidType = types.Typ[types.Invalid]
@@ -294,4 +296,9 @@ func identOf(e ast.Expr) *ast.Ident {
 	default:
 		return nil
 	}
+}
+
+func isTypeParam(typ types.Type) bool {
+	_, ok := typ.(*typeparams.TypeParam)
+	return ok
 }


### PR DESCRIPTION
Extended the dsl documentation to reflect the change:

	For expressions of unknown size, like type params in generics,
	any filter using this operand will fail.

We're not using 0 as a fallback size to avoid the confusion with zero-sized values like `struct{}`.

See https://github.com/go-critic/go-critic/pull/1237

Fixes #406