### PR TITLE
Add troubleshooting sectipon to README.md

### DIFF
--- a/_docs/rules.go
+++ b/_docs/rules.go
@@ -1,4 +1,5 @@
-// +build ignore
+//go:build ruleguard
+// +build ruleguard
 
 package gorules
 


### PR DESCRIPTION
This section explains two common problems found when trying to run ruleguard:

- the dsl package not being available
- the dsl package not being included as a dependency of the module

Fixes #408

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@gmail.com>