### PR TITLE
ruleguard: introduce reusable runner state

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,9 @@ require (
 	github.com/google/go-cmp v0.5.8
 	github.com/quasilyte/go-ruleguard/dsl v0.3.21
 	github.com/quasilyte/go-ruleguard/rules v0.0.0-20211022131956-028d6511ab71
-	github.com/quasilyte/gogrep v0.0.0-20220828223005-86e4605de09f
+	github.com/quasilyte/gogrep v0.0.0-20221002170714-e78263da2dd3
 	github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567
-	golang.org/x/exp/typeparams v0.0.0-20220827204233-334a2380cb91
+	golang.org/x/exp/typeparams v0.0.0-20221002003631-540bb7301a08
 	golang.org/x/tools v0.1.12
 )
 

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/quasilyte/go-ruleguard/rules v0.0.0-20211022131956-028d6511ab71 h1:CN
 github.com/quasilyte/go-ruleguard/rules v0.0.0-20211022131956-028d6511ab71/go.mod h1:4cgAphtvu7Ftv7vOT2ZOYhC6CvBxZixcasr8qIOTA50=
 github.com/quasilyte/gogrep v0.0.0-20220828223005-86e4605de09f h1:6Gtn2i04RD0gVyYf2/IUMTIs+qYleBt4zxDqkLTcu4U=
 github.com/quasilyte/gogrep v0.0.0-20220828223005-86e4605de09f/go.mod h1:Cm9lpz9NZjEoL1tgZ2OgeUKPIxL1meE7eo60Z6Sk+Ng=
+github.com/quasilyte/gogrep v0.0.0-20221002170714-e78263da2dd3 h1:sHk88D8fWc+SnmPUh5kt5rjR3X+ZR3aJoJPu/YfUbsM=
+github.com/quasilyte/gogrep v0.0.0-20221002170714-e78263da2dd3/go.mod h1:Cm9lpz9NZjEoL1tgZ2OgeUKPIxL1meE7eo60Z6Sk+Ng=
 github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567 h1:M8mH9eK4OUR4lu7Gd+PU1fV2/qnDNfzT635KRSObncs=
 github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567/go.mod h1:DWNGW8A4Y+GyBgPuaQJuWiy0XYftx4Xm/y5Jqk9I6VQ=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -29,6 +31,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/exp/typeparams v0.0.0-20220428152302-39d4317da171/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/exp/typeparams v0.0.0-20220827204233-334a2380cb91 h1:Ic/qN6TEifvObMGQy72k0n1LlJr7DjWWEi+MOsDOiSk=
 golang.org/x/exp/typeparams v0.0.0-20220827204233-334a2380cb91/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
+golang.org/x/exp/typeparams v0.0.0-20221002003631-540bb7301a08 h1:VpoGhesgULkabDHoDFGayS1wnkasmT95Jq2xZDwN45Q=
+golang.org/x/exp/typeparams v0.0.0-20221002003631-540bb7301a08/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 h1:6zppjxzCulZykYSLyVDYbneBfbaBIQPYMevg0bEwv2s=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=

--- a/ruleguard/engine.go
+++ b/ruleguard/engine.go
@@ -131,6 +131,7 @@ func (e *engine) Run(ctx *RunContext, buildContext *build.Context, f *ast.File) 
 }
 
 // engineState is a shared state inside the engine.
+// Its access is synchronized, unlike the RunnerState which should be thread-local.
 type engineState struct {
 	env *quasigo.Env
 

--- a/ruleguard/filters.go
+++ b/ruleguard/filters.go
@@ -23,9 +23,16 @@ func filterFailure(reason string) matchFilterResult {
 	return matchFilterResult(reason)
 }
 
-func exprListFilterApply(src string, list gogrep.ExprSlice, fn func(ast.Expr) bool) matchFilterResult {
-	for i := 0; i < list.Len(); i++ {
-		if !fn(list.At(i).(ast.Expr)) {
+func asExprSlice(x ast.Node) *gogrep.NodeSlice {
+	if x, ok := x.(*gogrep.NodeSlice); ok && x.Kind == gogrep.ExprNodeSlice {
+		return x
+	}
+	return nil
+}
+
+func exprListFilterApply(src string, list []ast.Expr, fn func(ast.Expr) bool) matchFilterResult {
+	for _, e := range list {
+		if !fn(e) {
 			return filterFailure(src)
 		}
 	}
@@ -99,12 +106,11 @@ func makeFileNameMatchesFilter(src string, re textmatch.Pattern) filterFunc {
 
 func makePureFilter(src, varname string) filterFunc {
 	return func(params *filterParams) matchFilterResult {
-		if list, ok := params.subNode(varname).(gogrep.ExprSlice); ok {
-			return exprListFilterApply(src, list, func(x ast.Expr) bool {
+		if list := asExprSlice(params.subNode(varname)); list != nil {
+			return exprListFilterApply(src, list.GetExprSlice(), func(x ast.Expr) bool {
 				return isPure(params.ctx.Types, x)
 			})
 		}
-
 		n := params.subExpr(varname)
 		if isPure(params.ctx.Types, n) {
 			return filterSuccess
@@ -115,8 +121,8 @@ func makePureFilter(src, varname string) filterFunc {
 
 func makeConstFilter(src, varname string) filterFunc {
 	return func(params *filterParams) matchFilterResult {
-		if list, ok := params.subNode(varname).(gogrep.ExprSlice); ok {
-			return exprListFilterApply(src, list, func(x ast.Expr) bool {
+		if list := asExprSlice(params.subNode(varname)); list != nil {
+			return exprListFilterApply(src, list.GetExprSlice(), func(x ast.Expr) bool {
 				return isConstant(params.ctx.Types, x)
 			})
 		}
@@ -131,8 +137,8 @@ func makeConstFilter(src, varname string) filterFunc {
 
 func makeConstSliceFilter(src, varname string) filterFunc {
 	return func(params *filterParams) matchFilterResult {
-		if list, ok := params.subNode(varname).(gogrep.ExprSlice); ok {
-			return exprListFilterApply(src, list, func(x ast.Expr) bool {
+		if list := asExprSlice(params.subNode(varname)); list != nil {
+			return exprListFilterApply(src, list.GetExprSlice(), func(x ast.Expr) bool {
 				return isConstantSlice(params.ctx.Types, x)
 			})
 		}
@@ -147,8 +153,8 @@ func makeConstSliceFilter(src, varname string) filterFunc {
 
 func makeAddressableFilter(src, varname string) filterFunc {
 	return func(params *filterParams) matchFilterResult {
-		if list, ok := params.subNode(varname).(gogrep.ExprSlice); ok {
-			return exprListFilterApply(src, list, func(x ast.Expr) bool {
+		if list := asExprSlice(params.subNode(varname)); list != nil {
+			return exprListFilterApply(src, list.GetExprSlice(), func(x ast.Expr) bool {
 				return isAddressable(params.ctx.Types, x)
 			})
 		}
@@ -163,8 +169,8 @@ func makeAddressableFilter(src, varname string) filterFunc {
 
 func makeComparableFilter(src, varname string) filterFunc {
 	return func(params *filterParams) matchFilterResult {
-		if list, ok := params.subNode(varname).(gogrep.ExprSlice); ok {
-			return exprListFilterApply(src, list, func(x ast.Expr) bool {
+		if list := asExprSlice(params.subNode(varname)); list != nil {
+			return exprListFilterApply(src, list.GetExprSlice(), func(x ast.Expr) bool {
 				return types.Comparable(params.typeofNode(x))
 			})
 		}
@@ -212,8 +218,8 @@ func makeCustomVarFilter(src, varname string, fn *quasigo.Func) filterFunc {
 
 func makeTypeImplementsFilter(src, varname string, iface *types.Interface) filterFunc {
 	return func(params *filterParams) matchFilterResult {
-		if list, ok := params.subNode(varname).(gogrep.ExprSlice); ok {
-			return exprListFilterApply(src, list, func(x ast.Expr) bool {
+		if list := asExprSlice(params.subNode(varname)); list != nil {
+			return exprListFilterApply(src, list.GetExprSlice(), func(x ast.Expr) bool {
 				return xtypes.Implements(params.typeofNode(x), iface)
 			})
 		}
@@ -322,8 +328,8 @@ func makeRootSinkTypeIsFilter(src string, pat *typematch.Pattern) filterFunc {
 func makeTypeIsFilter(src, varname string, underlying bool, pat *typematch.Pattern) filterFunc {
 	if underlying {
 		return func(params *filterParams) matchFilterResult {
-			if list, ok := params.subNode(varname).(gogrep.ExprSlice); ok {
-				return exprListFilterApply(src, list, func(x ast.Expr) bool {
+			if list := asExprSlice(params.subNode(varname)); list != nil {
+				return exprListFilterApply(src, list.GetExprSlice(), func(x ast.Expr) bool {
 					return pat.MatchIdentical(params.typematchState, params.typeofNode(x).Underlying())
 				})
 			}
@@ -336,8 +342,8 @@ func makeTypeIsFilter(src, varname string, underlying bool, pat *typematch.Patte
 	}
 
 	return func(params *filterParams) matchFilterResult {
-		if list, ok := params.subNode(varname).(gogrep.ExprSlice); ok {
-			return exprListFilterApply(src, list, func(x ast.Expr) bool {
+		if list := asExprSlice(params.subNode(varname)); list != nil {
+			return exprListFilterApply(src, list.GetExprSlice(), func(x ast.Expr) bool {
 				return pat.MatchIdentical(params.typematchState, params.typeofNode(x))
 			})
 		}
@@ -351,8 +357,8 @@ func makeTypeIsFilter(src, varname string, underlying bool, pat *typematch.Patte
 
 func makeTypeConvertibleToFilter(src, varname string, dstType types.Type) filterFunc {
 	return func(params *filterParams) matchFilterResult {
-		if list, ok := params.subNode(varname).(gogrep.ExprSlice); ok {
-			return exprListFilterApply(src, list, func(x ast.Expr) bool {
+		if list := asExprSlice(params.subNode(varname)); list != nil {
+			return exprListFilterApply(src, list.GetExprSlice(), func(x ast.Expr) bool {
 				return types.ConvertibleTo(params.typeofNode(x), dstType)
 			})
 		}
@@ -367,8 +373,8 @@ func makeTypeConvertibleToFilter(src, varname string, dstType types.Type) filter
 
 func makeTypeAssignableToFilter(src, varname string, dstType types.Type) filterFunc {
 	return func(params *filterParams) matchFilterResult {
-		if list, ok := params.subNode(varname).(gogrep.ExprSlice); ok {
-			return exprListFilterApply(src, list, func(x ast.Expr) bool {
+		if list := asExprSlice(params.subNode(varname)); list != nil {
+			return exprListFilterApply(src, list.GetExprSlice(), func(x ast.Expr) bool {
 				return types.AssignableTo(params.typeofNode(x), dstType)
 			})
 		}
@@ -433,8 +439,8 @@ func makeLineConstFilter(src, varname string, op token.Token, rhsValue constant.
 
 func makeTypeSizeConstFilter(src, varname string, op token.Token, rhsValue constant.Value) filterFunc {
 	return func(params *filterParams) matchFilterResult {
-		if list, ok := params.subNode(varname).(gogrep.ExprSlice); ok {
-			return exprListFilterApply(src, list, func(x ast.Expr) bool {
+		if list := asExprSlice(params.subNode(varname)); list != nil {
+			return exprListFilterApply(src, list.GetExprSlice(), func(x ast.Expr) bool {
 				typ := params.typeofNode(x)
 				if isTypeParam(typ) {
 					return false
@@ -474,8 +480,8 @@ func makeTypeSizeFilter(src, varname string, op token.Token, rhsVarname string) 
 
 func makeValueIntConstFilter(src, varname string, op token.Token, rhsValue constant.Value) filterFunc {
 	return func(params *filterParams) matchFilterResult {
-		if list, ok := params.subNode(varname).(gogrep.ExprSlice); ok {
-			return exprListFilterApply(src, list, func(x ast.Expr) bool {
+		if list := asExprSlice(params.subNode(varname)); list != nil {
+			return exprListFilterApply(src, list.GetExprSlice(), func(x ast.Expr) bool {
 				lhsValue := intValueOf(params.ctx.Types, x)
 				return lhsValue != nil && constant.Compare(lhsValue, op, rhsValue)
 			})
@@ -615,8 +621,8 @@ func makeObjectIsFilter(src, varname, objectName string) filterFunc {
 	}
 
 	return func(params *filterParams) matchFilterResult {
-		if list, ok := params.subNode(varname).(gogrep.ExprSlice); ok {
-			return exprListFilterApply(src, list, func(x ast.Expr) bool {
+		if list := asExprSlice(params.subNode(varname)); list != nil {
+			return exprListFilterApply(src, list.GetExprSlice(), func(x ast.Expr) bool {
 				ident := identOf(x)
 				return ident != nil && predicate(params.ctx.Types.ObjectOf(ident))
 			})

--- a/ruleguard/nodepath.go
+++ b/ruleguard/nodepath.go
@@ -10,8 +10,8 @@ type nodePath struct {
 	stack []ast.Node
 }
 
-func newNodePath() nodePath {
-	return nodePath{stack: make([]ast.Node, 0, 32)}
+func newNodePath() *nodePath {
+	return &nodePath{stack: make([]ast.Node, 0, 32)}
 }
 
 func (p nodePath) String() string {
@@ -22,15 +22,15 @@ func (p nodePath) String() string {
 	return strings.Join(parts, "/")
 }
 
-func (p nodePath) Parent() ast.Node {
+func (p *nodePath) Parent() ast.Node {
 	return p.NthParent(1)
 }
 
-func (p nodePath) Current() ast.Node {
+func (p *nodePath) Current() ast.Node {
 	return p.NthParent(0)
 }
 
-func (p nodePath) NthParent(n int) ast.Node {
+func (p *nodePath) NthParent(n int) ast.Node {
 	index := uint(len(p.stack) - n - 1)
 	if index < uint(len(p.stack)) {
 		return p.stack[index]

--- a/ruleguard/perf_test.go
+++ b/ruleguard/perf_test.go
@@ -60,7 +60,7 @@ func BenchmarkEngineRun(b *testing.B) {
 	}
 	`
 	e := benchNewEngine(b, src)
-	ctx, files := benchRunContext(b)
+	ctx, files := benchRunContext(e, b)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -115,7 +115,7 @@ func embedsMutex(ctx *dsl.VarFilterContext) bool {
 }
 	`
 	e := benchNewEngine(b, src)
-	ctx, files := benchRunContext(b)
+	ctx, files := benchRunContext(e, b)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -127,7 +127,7 @@ func embedsMutex(ctx *dsl.VarFilterContext) bool {
 	}
 }
 
-func benchRunContext(b *testing.B) (*RunContext, []*ast.File) {
+func benchRunContext(e *Engine, b *testing.B) (*RunContext, []*ast.File) {
 	b.Helper()
 
 	fset := token.NewFileSet()
@@ -163,6 +163,7 @@ func benchRunContext(b *testing.B) (*RunContext, []*ast.File) {
 		Report: func(data *ReportData) {
 			// Do nothing.
 		},
+		State: NewRunnerState(e),
 	}
 
 	return ctx, files

--- a/ruleguard/ruleguard.go
+++ b/ruleguard/ruleguard.go
@@ -8,6 +8,9 @@ import (
 	"io"
 
 	"github.com/quasilyte/go-ruleguard/ruleguard/ir"
+	"github.com/quasilyte/go-ruleguard/ruleguard/quasigo"
+	"github.com/quasilyte/go-ruleguard/ruleguard/typematch"
+	"github.com/quasilyte/gogrep"
 )
 
 // Engine is the main ruleguard package API object.
@@ -88,6 +91,21 @@ type LoadContext struct {
 	Fset *token.FileSet
 }
 
+type RunnerState struct {
+	gogrepState    gogrep.MatcherState
+	gogrepSubState gogrep.MatcherState
+	nodePath       *nodePath
+	evalEnv        *quasigo.EvalEnv
+	typematchState *typematch.MatcherState
+
+	object *rulesRunner
+}
+
+// NewRunnerState creates a state object that can be used with RunContext.
+func NewRunnerState(e *Engine) *RunnerState {
+	return newRunnerState(e.impl.state)
+}
+
 type RunContext struct {
 	Debug        string
 	DebugImports bool
@@ -115,6 +133,20 @@ type RunContext struct {
 	// Note that this value is ignored for Suggest templates.
 	// Ruleguard doesn't truncate suggested replacement candidates.
 	TruncateLen int
+
+	// State is an object that contains reusable resources needed for the rules to be executed.
+	//
+	// If nil, a new state will be allocated.
+	//
+	// The State object access is not synchronized.
+	// State should not be shared between multiple goroutines.
+	// There are 3 patterns that are safe:
+	// 1. For single-threaded programs, you can use a single state.
+	// 2. For controlled concurrency with workers, you can use a per-worker state.
+	// 3. For uncontrolled concurrency you can use a sync.Pool of states.
+	//
+	// Reusing the state properly can increase the performance significantly.
+	State *RunnerState
 }
 
 type ReportData struct {


### PR DESCRIPTION
This allows more memory reuse between ruleguard engine executions.

Usually, app only needs one Engine object, which doesn't require any synchronization. For optimal execution, there should be N `RunnerState` objects, where N is number of concurrently executing goroutines that use same `Engine`.

    name         old time/op    new time/op    delta
    EngineRun-8     231µs ± 1%     197µs ± 0%  -14.72%  (p=0.000 n=9+10)
    Issue412-8      205µs ± 1%     196µs ± 1%   -4.46%  (p=0.000 n=10+10)

    name         old alloc/op   new alloc/op   delta
    EngineRun-8    23.5kB ± 0%     9.1kB ± 0%  -61.26%  (p=0.000 n=8+8)
    Issue412-8     9.54kB ± 0%    1.81kB ± 0%  -81.03%  (p=0.000 n=8+7)