### PR TITLE
Make goenv parsing robust across go versions and OSes

### DIFF
--- a/internal/goenv/goenv.go
+++ b/internal/goenv/goenv.go
@@ -3,46 +3,24 @@ package goenv
 import (
 	"errors"
 	"os/exec"
-	"runtime"
-	"strconv"
 	"strings"
 )
 
-func Read() (map[string]string, error) {
-	out, err := exec.Command("go", "env").CombinedOutput()
+func Read(varNames []string) (map[string]string, error) {
+	out, err := exec.Command("go", append([]string{"env"}, varNames...)...).CombinedOutput()
 	if err != nil {
 		return nil, err
 	}
-	return parseGoEnv(out, runtime.GOOS)
+	return parseGoEnv(varNames, out)
 }
 
-func parseGoEnv(data []byte, goos string) (map[string]string, error) {
+func parseGoEnv(varNames []string, data []byte) (map[string]string, error) {
 	vars := make(map[string]string)
 
 	lines := strings.Split(strings.ReplaceAll(string(data), "\r\n", "\n"), "\n")
-
-	if goos == "windows" {
-		// Line format is: `set $name=$value`
-		for _, l := range lines {
-			l = strings.TrimPrefix(l, "set ")
-			parts := strings.Split(l, "=")
-			if len(parts) != 2 {
-				continue
-			}
-			vars[parts[0]] = parts[1]
-		}
-	} else {
-		// Line format is: `$name="$value"`
-		for _, l := range lines {
-			parts := strings.Split(strings.TrimSpace(l), "=")
-			if len(parts) != 2 {
-				continue
-			}
-			val, err := strconv.Unquote(parts[1])
-			if err != nil {
-				continue
-			}
-			vars[parts[0]] = val
+	for i, varName := range varNames {
+		if i < len(lines) && len(lines[i]) > 0 {
+			vars[varName] = lines[i]
 		}
 	}
 

--- a/ruleguard/engine.go
+++ b/ruleguard/engine.go
@@ -248,7 +248,7 @@ func inferBuildContext() *build.Context {
 	// Inherit most fields from the build.Default.
 	ctx := build.Default
 
-	env, err := goenv.Read()
+	env, err := goenv.Read([]string{"GOROOT", "GOPATH", "GOARCH", "GOOS", "CGO_ENABLED"})
 	if err != nil {
 		return &ctx
 	}


### PR DESCRIPTION
Fixes https://github.com/quasilyte/go-ruleguard/issues/449