### PR TITLE
Make go env vars static

### DIFF
--- a/internal/goenv/goenv.go
+++ b/internal/goenv/goenv.go
@@ -6,12 +6,14 @@ import (
 	"strings"
 )
 
-func Read(varNames []string) (map[string]string, error) {
-	out, err := exec.Command("go", append([]string{"env"}, varNames...)...).CombinedOutput()
+func Read() (map[string]string, error) {
+	// pass in a fixed set of var names to avoid needing to unescape output
+	// pass in literals here instead of a variable list to avoid security linter warnings about command injection
+	out, err := exec.Command("go", "env", "GOROOT", "GOPATH", "GOARCH", "GOOS", "CGO_ENABLED").CombinedOutput()
 	if err != nil {
 		return nil, err
 	}
-	return parseGoEnv(varNames, out)
+	return parseGoEnv([]string{"GOROOT", "GOPATH", "GOARCH", "GOOS", "CGO_ENABLED"}, out)
 }
 
 func parseGoEnv(varNames []string, data []byte) (map[string]string, error) {

--- a/ruleguard/engine.go
+++ b/ruleguard/engine.go
@@ -248,7 +248,7 @@ func inferBuildContext() *build.Context {
 	// Inherit most fields from the build.Default.
 	ctx := build.Default
 
-	env, err := goenv.Read([]string{"GOROOT", "GOPATH", "GOARCH", "GOOS", "CGO_ENABLED"})
+	env, err := goenv.Read()
 	if err != nil {
 		return &ctx
 	}


### PR DESCRIPTION
Try to make the security linter happier:

```
Error: internal/goenv/goenv.go:10:14: G204: Subprocess launched with a potential tainted input or cmd arguments (gosec)
	out, err := exec.Command("go", append([]string{"env"}, varNames...)...).CombinedOutput()
	            ^
```