### PR TITLE
ruleguard: fix typos

### DIFF
--- a/_docs/dsl.md
+++ b/_docs/dsl.md
@@ -65,7 +65,7 @@ To add such documentation, use special pragmas when commenting a matcher functio
 //doc:summary reports always false/true conditions
 //doc:before  strings.Count(s, "/") >= 0
 //doc:after   strings.Count(s, "/") > 0
-//doc:tags    diagnostic exprimental
+//doc:tags    diagnostic experimental
 func badCond(m dsl.Matcher) {
 	m.Match(`strings.Count($_, $_) >= 0`).Report(`statement always true`)
 	m.Match(`bytes.Count($_, $_) >= 0`).Report(`statement always true`)

--- a/_docs/rules.go
+++ b/_docs/rules.go
@@ -230,7 +230,7 @@ func gocriticBadCall(m dsl.Matcher) {
 		`bytes.Replace($_, $_, $_, 0)`,
 		`strings.SplitN($_, $_, 0)`,
 		`bytes.SplitN($_, $_, 0)`).
-		Report(`n=0 argument does nothing, maybe n=-1 is indended?`)
+		Report(`n=0 argument does nothing, maybe n=-1 is intended?`)
 
 	m.Match(`append($_)`).
 		Report(`append called with 1 argument does nothing`)

--- a/analyzer/testdata/src/gocritic/f1.go
+++ b/analyzer/testdata/src/gocritic/f1.go
@@ -60,7 +60,7 @@ func appendCombine2(xs []int, aa []int, bb []int) []int {
 }
 
 func badCall(s string, xs []int) {
-	_ = strings.Replace(s, "a", "b", 0) // want `\Qn=0 argument does nothing, maybe n=-1 is indended?`
+	_ = strings.Replace(s, "a", "b", 0) // want `\Qn=0 argument does nothing, maybe n=-1 is intended?`
 	_ = append(xs)                      // want `\Qappend called with 1 argument does nothing`
 }
 

--- a/analyzer/testdata/src/gocritic/rules.go
+++ b/analyzer/testdata/src/gocritic/rules.go
@@ -54,7 +54,7 @@ func testRules(m dsl.Matcher) {
 		Report(`$dst=append($x,$a,$b) is faster`)
 
 	m.Match(`strings.Replace($_, $_, $_, 0)`).
-		Report(`n=0 argument does nothing, maybe n=-1 is indended?`)
+		Report(`n=0 argument does nothing, maybe n=-1 is intended?`)
 
 	m.Match(`append($_)`).
 		Report(`append called with 1 argument does nothing`)

--- a/dsl/dsl.go
+++ b/dsl/dsl.go
@@ -106,7 +106,7 @@ type Var struct {
 	Const bool
 
 	// ConstSlice reports whether expr matched by var is a slice literal
-	// consisting of contant elements.
+	// consisting of constant elements.
 	//
 	// We need a separate Const-like predicate here because Go doesn't
 	// treat slices of const elements as constants, so including

--- a/ruleguard/ir_loader.go
+++ b/ruleguard/ir_loader.go
@@ -195,7 +195,7 @@ func (l *irLoader) compileFilterFuncs(filename string, irfile *ir.File) error {
 	if err != nil {
 		// If this ever happens, user will get unexpected error
 		// lines for it; but we should trust that 99.9% errors
-		// should be catched at irconv phase so we get a valid Go
+		// should be caught at irconv phase so we get a valid Go
 		// source here as well?
 		return fmt.Errorf("parse custom decls: %w", err)
 	}

--- a/ruleguard/quasigo/eval_test.go
+++ b/ruleguard/quasigo/eval_test.go
@@ -87,7 +87,7 @@ func TestEval(t *testing.T) {
 		{`foo.Method1(40)`, "Hello40"},
 		{`newFoo("x").Method1(11)`, "x11"},
 
-		// Accesing the fields.
+		// Accessing the fields.
 		{`foo.Prefix`, "Hello"},
 
 		// Nil checks.

--- a/ruleguard/ruleguard_test.go
+++ b/ruleguard/ruleguard_test.go
@@ -31,7 +31,7 @@ func TestTruncateText(t *testing.T) {
 	for _, test := range tests {
 		have := string(truncateText([]byte(test.input), test.maxLen))
 		if len(have) > test.maxLen {
-			t.Errorf("truncateText(%q, %v): len %d exceeeds max len",
+			t.Errorf("truncateText(%q, %v): len %d exceeds max len",
 				test.input, test.maxLen, len(have))
 		}
 		if len(test.input) > test.maxLen && len(have) != test.maxLen {

--- a/ruleguard/textmatch/textmatch.go
+++ b/ruleguard/textmatch/textmatch.go
@@ -9,7 +9,7 @@ type Pattern interface {
 }
 
 // Compile parses a regular expression and returns a compiled
-// pattern that can match inputs descriped by the regexp.
+// pattern that can match inputs described by the regexp.
 //
 // Semantically it's close to the regexp.Compile, but
 // it does recognize some common patterns and creates

--- a/ruleguard/utils.go
+++ b/ruleguard/utils.go
@@ -273,7 +273,7 @@ func isTypeExpr(info *types.Info, x ast.Expr) bool {
 
 	case *ast.Ident:
 		// Identifier may be a type expression if object
-		// it reffers to is a type name.
+		// it refers to is a type name.
 		_, ok := info.ObjectOf(x).(*types.TypeName)
 		return ok
 


### PR DESCRIPTION
This PR corrects spelling mistakes in comments and reports.