### PR TITLE
Support alias types in typeIdentical()

### DIFF
--- a/internal/xtypes/xtypes.go
+++ b/internal/xtypes/xtypes.go
@@ -221,6 +221,10 @@ func typeIdentical(x, y types.Type, p *ifacePair) bool {
 	case *typeparams.TypeParam:
 		// nothing to do (x and y being equal is caught in the very beginning of this function)
 
+	case *types.Alias:
+		// an alias type is identical if the type it's an alias of is identical to it.
+		return typeIdentical(x.Rhs(), y, p)
+
 	case nil:
 		// avoid a crash in case of nil type
 


### PR DESCRIPTION
This is a possible implementation of types.Type as of Go 1.22, and gets created by default starting in Go 1.23. This currently causes a panic when running under Go 1.23, because of the default `panic("unreachable")` in this switch statement.