### PR TITLE
chore: fix CI ang go1.22 support

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@
         { name: "Check out code into the Go module directory", uses: "actions/checkout@v4" },
         {
           name: "Set up Go ${{ matrix.go-version }}",
-          uses: "actions/setup-go@v4",
+          uses: "actions/setup-go@v5",
           with: { "go-version": "${{ matrix.go-version }}" },
           id: "go",
         },

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,8 @@
 {
   "run": {
     # timeout for analysis, e.g. 30s, 5m, default is 1m
-    "deadline": "3m",
+    "timeout": "3m",
   },
-  "fast": false,
   "linters": {
     "enable": [
       "errcheck",
@@ -22,29 +21,22 @@
       "unparam",
       "unused",
     ],
+    "disable": [
+      "depguard",
+      "dupl",
+      "gocyclo",
+      "lll",
+      "prealloc",
+    ],
   },
-  "disable": [
-    "deadcode", # deprecated
-    "depguard",
-    "dupl",
-    "exhaustivestruct", # deprecated
-    "gocyclo",
-    "golint", # deprecated
-    "ifshort", # deprecated
-    "interfacer", # deprecated
-    "lll",
-    "maligned", # deprecated
-    "nosnakecase", # deprecated
-    "prealloc",
-    "scopelint", # deprecated
-    "structcheck", # deprecated
-    "varcheck", # deprecated
-  ],
   "linters-settings": {
     "gocritic": {
       "enabled-checks": [
         "commentedOutCode",
       ],
     },
+    "gosec": {
+      "excludes": ["G115"]
+    }
   },
 }

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ test-release:
 	@echo "everything is OK"
 
 lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH_DIR)/bin v1.54.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH_DIR)/bin v1.60.2
 	$(GOPATH_DIR)/bin/golangci-lint run ./...
 	go build -o go-ruleguard ./cmd/ruleguard
 	./go-ruleguard -debug-imports -rules rules.go ./...

--- a/internal/xtypes/xtypes.go
+++ b/internal/xtypes/xtypes.go
@@ -223,7 +223,7 @@ func typeIdentical(x, y types.Type, p *ifacePair) bool {
 
 	case *types.Alias:
 		// an alias type is identical if the type it's an alias of is identical to it.
-		return typeIdentical(x.Rhs(), y, p)
+		return typeIdentical(types.Unalias(x), y, p)
 
 	case nil:
 		// avoid a crash in case of nil type

--- a/ruleguard/irconv/irconv.go
+++ b/ruleguard/irconv/irconv.go
@@ -618,8 +618,7 @@ func (conv *converter) convertFilterExprImpl(e ast.Expr) ir.FilterExpr {
 	case *ast.UnaryExpr:
 		x := conv.convertFilterExpr(e.X)
 		args := []ir.FilterExpr{x}
-		switch e.Op {
-		case token.NOT:
+		if e.Op == token.NOT {
 			return ir.FilterExpr{Op: ir.FilterNotOp, Args: args}
 		}
 

--- a/ruleguard/irprint/irprint.go
+++ b/ruleguard/irprint/irprint.go
@@ -95,7 +95,8 @@ func (p *printer) printReflectElemNoNewline(key string, v reflect.Value, insideL
 		}
 	}
 
-	if v.Type().Kind() == reflect.Struct {
+	switch v.Type().Kind() {
+	case reflect.Struct:
 		if !insideList {
 			p.buf.WriteString(v.Type().String())
 		}
@@ -104,7 +105,8 @@ func (p *printer) printReflectElemNoNewline(key string, v reflect.Value, insideL
 			p.printReflectElem(v.Type().Field(i).Name, v.Field(i), false)
 		}
 		p.writef("},")
-	} else if v.Type().Kind() == reflect.Slice {
+
+	case reflect.Slice:
 		if isCompactSlice(v) {
 			p.writef("%s{", v.Type())
 			for j := 0; j < v.Len(); j++ {
@@ -119,7 +121,7 @@ func (p *printer) printReflectElemNoNewline(key string, v reflect.Value, insideL
 			p.writef("},")
 		}
 
-	} else {
+	default:
 		switch val := v.Interface().(type) {
 		case int64:
 			p.writef("int64(%v),", val)

--- a/ruleguard/quasigo/compile.go
+++ b/ruleguard/quasigo/compile.go
@@ -605,11 +605,12 @@ func (cl *compiler) compileCall(key funcKey, sig *types.Signature, args []ast.Ex
 	}
 
 	var op opcode
-	if sig.Results().Len() == 0 {
+	switch {
+	case sig.Results().Len() == 0:
 		op = opVoidCall
-	} else if typeIsInt(sig.Results().At(0).Type()) {
+	case typeIsInt(sig.Results().At(0).Type()):
 		op = opIntCall
-	} else {
+	default:
 		op = opCall
 	}
 

--- a/ruleguard/ruleguard_error_test.go
+++ b/ruleguard/ruleguard_error_test.go
@@ -150,13 +150,13 @@ func TestParseFilterFuncError(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		file := fmt.Sprintf(`
+		file := `
 			package gorules
 			import "github.com/quasilyte/go-ruleguard/dsl"
 			type Foo struct { X int }
 			func (foo *Foo) String() string { return "" }
 			func g(ctx *dsl.VarFilterContext) bool { return false }
-			` + test.src)
+			` + test.src
 		e := NewEngine()
 		ctx := &LoadContext{
 			Fset: token.NewFileSet(),


### PR DESCRIPTION
- update golangci-lint to v1.60.2 (go1.23 support)
- fix golangci-lint configuration
- fix go-critic reports